### PR TITLE
add source block to solve multiple primary source warning

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,7 @@
 source 'https://rubygems.org'
-source 'https://rails-assets.org'
+source 'https://rails-assets.org' do
+  gem 'rails-assets-highcharts', '~> 4.0.4'
+end
 
 ruby '2.2.1'
 
@@ -14,7 +16,6 @@ gem 'platform-api', '~> 0.2.0'
 gem 'haml', '~> 4.0.5'
 gem 'bootstrap-sass', '~> 3.3.3'
 gem 'pygments.rb', '~> 0.6.0'
-gem 'rails-assets-highcharts', '~> 4.0.4'
 gem 'redis', '~> 3.2.1'
 gem 'redis-rails', '~> 4.0.0'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -253,7 +253,7 @@ DEPENDENCIES
   pygments.rb (~> 0.6.0)
   rack-mini-profiler (~> 0.9.3)
   rails (= 4.2.0)
-  rails-assets-highcharts (~> 4.0.4)
+  rails-assets-highcharts (~> 4.0.4)!
   rails_12factor
   redis (~> 3.2.1)
   redis-rails (~> 4.0.0)


### PR DESCRIPTION
```bundle``` commands shows up a warning message like the following.
```
Warning: this Gemfile contains multiple primary sources. Using `source` more than once without
a block is a security risk, and may result in installing unexpected gems. To resolve this 
warning, use a block to indicate which gems should come from the secondary source. To upgrade
this warning to an error, run `bundle config disable_multisource true`.
```

PR solve this security fix, and disable warning message.