### PR TITLE
fix back and forward reloading of graphs by storing relevant data into h...

### DIFF
--- a/app/assets/javascripts/initialize.js
+++ b/app/assets/javascripts/initialize.js
@@ -1,4 +1,4 @@
-$(document).ready(function() {
+var init = function() {
   var locationPathName = location.pathname != '/' ? location.pathname : '/ruby/ruby/releases';
   $(".top-nav a[href='" + locationPathName + "']").addClass('current');
 
@@ -38,7 +38,9 @@ $(document).ready(function() {
         $('html,body').animate({scrollTop:0},0);
 
         if (history && history.pushState) {
-          history.pushState(null, '',
+          history.pushState(
+            { result_type: resultType, display_count: benchmarkRunDisplayCount },
+            '',
             "/" +
             organizationName +
             "/" + repoName +
@@ -81,4 +83,35 @@ $(document).ready(function() {
     drawReleaseChart(".release-chart");
     drawChart(".chart");
   })
-})
+}
+
+var fetchBenchmarks = function() {
+  var $spinner = $(".spinner");
+  if (window.history && window.history.pushState) {
+    $(window).on('popstate', function(event) {
+      var previousState = event.originalEvent.state;
+      var currentPath = location.pathname;
+      xhr = $.ajax({
+        url: currentPath,
+        type: 'GET',
+        data: previousState,
+        dataType: 'script',
+        beforeSend: function() {
+          $spinner.toggleClass('hide');
+          $("#chart-container").empty();
+          $('html,body').animate({scrollTop:0},0);
+        },
+        complete: function() {
+          $spinner.toggleClass('hide');
+          $("#benchmark_run_display_count").val(previousState.display_count);
+          $("input[name=result_type][value="+previousState.result_type+"").prop('checked', true);
+        }
+      });
+    });
+  }
+}
+
+$(document).ready(function() {
+  init();
+  fetchBenchmarks();
+});

--- a/test/acceptance/view_benchmark_graphs_test.rb
+++ b/test/acceptance/view_benchmark_graphs_test.rb
@@ -72,8 +72,58 @@ class ViewBenchmarkGraphsTest < AcceptanceTest
     assert_not page.has_content?("#{benchmark_run_category_humanize} memory Graph")
   end
 
+  test "User should be able to view long running benchmark graphs when they go back and forward 
+    in the broswer window" do
+
+    benchmark_run = benchmark_runs(:array_iterations_run2)
+    benchmark_run2 = benchmark_runs(:array_count_run)
+    benchmark_run_category_humanize = benchmark_run.benchmark_type.category.humanize
+    benchmark_run2_category_humanize = benchmark_run2.benchmark_type.category.humanize
+
+    visit '/ruby/ruby/commits'
+
+    assert page.has_content?(
+      I18n.t('repos.show.title', repo_name: benchmark_run.initiator.repo.name.capitalize)
+    )
+
+    assert page.has_content?(I18n.t('repos.show.select_benchmark'))
+
+    within "form" do
+      choose(benchmark_run.benchmark_type.category)
+    end
+
+    assert page.has_content?("#{benchmark_run_category_humanize} Graph")
+    assert page.has_content?("#{benchmark_run_category_humanize} memory Graph")
+    assert page.has_content?("#{benchmark_run_category_humanize} Script")
+
+    within "form" do
+      choose(benchmark_run2.benchmark_type.category)
+    end
+
+    assert page.has_css?(".chart .highcharts-container")
+    assert page.has_content?("#{benchmark_run2_category_humanize} Graph")
+    assert_not page.has_content?("#{benchmark_run2_category_humanize} memory Graph")
+
+    page.evaluate_script('window.history.back()')
+    
+    assert page.has_content?("#{benchmark_run_category_humanize} Graph")
+    assert page.has_content?("#{benchmark_run_category_humanize} memory Graph")
+    assert page.has_content?("#{benchmark_run_category_humanize} Script")
+
+    page.evaluate_script('window.history.forward()')
+   
+    assert page.has_css?(".chart .highcharts-container")
+    assert page.has_content?("#{benchmark_run2_category_humanize} Graph")
+    assert_not page.has_content?("#{benchmark_run2_category_humanize} memory Graph")
+  end
+
   test "User should be able to select number of benchmark runs to display
     for long running benchmark graphs" do
+
+    javascript_driver = Capybara.javascript_driver
+    default_driver = Capybara.current_driver
+    Capybara.javascript_driver = :selenium
+    Capybara.current_driver = :selenium
 
     benchmark_type = benchmark_types(:array_count)
 
@@ -86,6 +136,40 @@ class ViewBenchmarkGraphsTest < AcceptanceTest
         select 3, from: "benchmark_run_display_count"
 
         assert assert_selector(".highcharts-markers path", count: 3)
+      end
+    end
+  end
+
+  test "User should be able to view long running benchmark graphs after they select different number of benchmark 
+  runs, when they go back and forward in the broswer window" do
+
+    javascript_driver = Capybara.javascript_driver
+    default_driver = Capybara.current_driver
+    Capybara.javascript_driver = :selenium
+    Capybara.current_driver = :selenium
+
+    benchmark_type = benchmark_types(:array_count)
+
+    BenchmarkRun.stub_const(:PAGINATE_COUNT, [1, 3]) do
+      BenchmarkRun.stub_const(:DEFAULT_PAGINATE_COUNT, 1) do
+        visit "/ruby/ruby/commits?result_type=#{benchmark_type.category}"
+
+        assert assert_selector(".highcharts-markers path", count: 1)
+
+        select 3, from: "benchmark_run_display_count"
+
+        assert assert_selector(".highcharts-markers path", count: 3)
+
+        select 1, from: "benchmark_run_display_count"
+
+        page.evaluate_script('window.history.back()')
+
+        assert page.has_selector? '#benchmark_run_display_count', text: 3
+
+        page.evaluate_script('window.history.forward()')
+
+        assert assert_selector(".highcharts-markers path", count: 1)
+        assert page.has_selector? '#benchmark_run_display_count', text: 1
       end
     end
   end
@@ -182,6 +266,89 @@ class ViewBenchmarkGraphsTest < AcceptanceTest
       URI.parse(page.current_url).request_uri,
       "/#{benchmark_run.initiator.repo.organization.name}" \
       "/#{benchmark_run.initiator.repo.name}/releases?result_type=#{benchmark_run.benchmark_type.category}"
+    )
+  end
+
+  test "User should be able to view releases benchmark graphs when they go back and forward 
+    in the broswer window" do
+
+    benchmark_run = benchmark_runs(:array_iterations_run)
+    benchmark_run2 = benchmark_runs(:array_count_run)
+    benchmark_run2_category_humanize = benchmark_run2.benchmark_type.category.humanize
+    benchmark_run_category_humanize = benchmark_run.benchmark_type.category.humanize
+    
+    visit '/ruby/ruby/releases'
+
+    within "form" do
+      choose(benchmark_run.benchmark_type.category)
+    end
+
+    within ".release-chart .highcharts-container .highcharts-yaxis-title",
+      match: :first do
+
+      assert page.has_content?(benchmark_run.benchmark_type.unit.capitalize)
+    end
+
+    assert page.has_content?("#{benchmark_run_category_humanize} Graph")
+    assert page.has_content?("#{benchmark_run_category_humanize} Script")
+
+    assert_equal(
+      URI.parse(page.current_url).request_uri,
+      "/#{benchmark_run.initiator.repo.organization.name}" \
+      "/#{benchmark_run.initiator.repo.name}/releases?result_type=#{benchmark_run.benchmark_type.category}"
+    )
+
+    within "form" do
+      choose(benchmark_run2.benchmark_type.category)
+    end
+
+    within ".release-chart .highcharts-container .highcharts-yaxis-title",
+      match: :first do
+
+      assert page.has_content?(benchmark_run2.benchmark_type.unit.capitalize)
+    end
+
+    assert page.has_content?("#{benchmark_run2_category_humanize} Graph")
+    assert page.has_content?("#{benchmark_run2_category_humanize} Script")
+
+    assert_equal(
+      URI.parse(page.current_url).request_uri,
+      "/#{benchmark_run2.initiator.repo.organization.name}" \
+      "/#{benchmark_run2.initiator.repo.name}/releases?result_type=#{benchmark_run2.benchmark_type.category}"
+    )
+
+    page.evaluate_script('window.history.back()')
+
+    within ".release-chart .highcharts-container .highcharts-yaxis-title",
+      match: :first do
+
+      assert page.has_content?(benchmark_run.benchmark_type.unit.capitalize)
+    end
+
+    assert page.has_content?("#{benchmark_run_category_humanize} Graph")
+    assert page.has_content?("#{benchmark_run_category_humanize} Script")
+
+    assert_equal(
+      URI.parse(page.current_url).request_uri,
+      "/#{benchmark_run.initiator.repo.organization.name}" \
+      "/#{benchmark_run.initiator.repo.name}/releases?result_type=#{benchmark_run.benchmark_type.category}"
+    )
+
+    page.evaluate_script('window.history.forward()')
+
+    within ".release-chart .highcharts-container .highcharts-yaxis-title",
+      match: :first do
+
+      assert page.has_content?(benchmark_run2.benchmark_type.unit.capitalize)
+    end
+
+    assert page.has_content?("#{benchmark_run2_category_humanize} Graph")
+    assert page.has_content?("#{benchmark_run2_category_humanize} Script")
+
+    assert_equal(
+      URI.parse(page.current_url).request_uri,
+      "/#{benchmark_run2.initiator.repo.organization.name}" \
+      "/#{benchmark_run2.initiator.repo.name}/releases?result_type=#{benchmark_run2.benchmark_type.category}"
     )
   end
 


### PR DESCRIPTION
@tgxworld This fixes #39 . 

So I tried different methods of figuring out the problems, thinking it was about jQuery not loading the cache properly, then realising that the previous code used the HTML5 history state. So, I reused the history state, to reload the relevant data (which is stored for each push) whenever the user clicks forward or back. Works in local, but will need to test it in staging.
