### PR TITLE
Disable webkit appearance for select element

### DIFF
--- a/app/assets/stylesheets/modules/_body.scss
+++ b/app/assets/stylesheets/modules/_body.scss
@@ -1,3 +1,7 @@
 .btn {
   border-radius: 100px;
 }
+
+.input-group select {
+  -webkit-appearance: inherit;
+}


### PR DESCRIPTION
On Chrome, initially it was:
![screen shot 2015-06-02 at 7 23 01 pm](https://cloud.githubusercontent.com/assets/1315101/7934775/289c5a3e-095d-11e5-941a-da909c4d36a0.png)

I changed it to:
![screen shot 2015-06-02 at 7 22 54 pm](https://cloud.githubusercontent.com/assets/1315101/7934780/2fee5f12-095d-11e5-9c2a-0ce72506f019.png)

