### PR TITLE
Grammar fixes

### DIFF
--- a/app/views/static_pages/hardware.html.haml
+++ b/app/views/static_pages/hardware.html.haml
@@ -16,11 +16,11 @@
             %span.l-text-hidden rubytune.name
 
       %p
-        All benchmarks are ran on a bare metal server in order to achieve
+        All benchmarks are run on a bare metal server in order to achieve
         consistent and repeatable results. We
         %strong will not
         publish CPU results gathered on virtual hosts where we can not control
-        our CPU allocation. The only results published are ran on
+        our CPU allocation. All published results were run on
         production level bare metal servers.
 
       %p

--- a/app/views/static_pages/landing.html.haml
+++ b/app/views/static_pages/landing.html.haml
@@ -26,7 +26,7 @@
               = link_to 'Discourse benchmark scripts',
                   'https://github.com/discourse/discourse/blob/master/script/bench.rb',
                   target: '_blank'
-              have been implemented and is ran for every commit and release. If you've
+              have been implemented and are run for every commit and release. If you've
               noticed a regression, feel free to use RubyBench when opening a new issue.
             %p
               = link_to "Try out RubyBench! →", releases_repo_path(organization_name: 'ruby', repo_name: 'ruby'), class: 'btn btn-primary'
@@ -54,7 +54,7 @@
 
           .col-md-6.col-md-pull-6
             %h2 Hardware
-            %p All benchmarks are ran on production level bare metal server in order to ensure consistent and repeatable results. More information about our bare metal server can be found on our hardware page.
+            %p All benchmarks are run on production level bare metal server in order to ensure consistent and repeatable results. More information about our bare metal server can be found on our hardware page.
             %p
               = link_to "View Hardware →", hardware_path, class: 'btn btn-primary'
 


### PR DESCRIPTION
This is actually mostly a reversion of https://github.com/ruby-bench/ruby-bench-web/pull/88 -- not sure why that happened, but it's incorrect.  The benchmarks "are run", not "are ran".