### PR TITLE
Fix failing view_benchmark_graph_commit_modal_test

### DIFF
--- a/test/acceptance/view_benchmark_graph_commit_modal_test.rb
+++ b/test/acceptance/view_benchmark_graph_commit_modal_test.rb
@@ -76,6 +76,7 @@ class ViewBenchmarkGraphCommitModalTest < AcceptanceTest
 
       markers = page.all(".highcharts-markers.highcharts-tracker path")
       # Markers are found from right to left on the graph
+      markers[1].click
       markers[0].click
       commit = benchmark_run3.initiator
 


### PR DESCRIPTION
I think we should open an issue on capybara-webkit, it is weird that first click does nothing. I tried:

```Ruby
p markers[0].inspect
p markers[0].path
```
and got
> `#<Capybara::Element tag="path">`
> Capybara::NotSupportedByDriverError: Capybara::Driver::Node#path

Something is definitely not right.