### PR TITLE
remove unused Displaycount

### DIFF
--- a/app/assets/javascripts/initialize.js
+++ b/app/assets/javascripts/initialize.js
@@ -22,10 +22,8 @@ $(document).on('ready page:load', function() {
     var benchmarkRunDisplayCount = $('#benchmark_run_display_count').val();
 
     if (benchmarkRunDisplayCount !== undefined) {
-      displayCount = benchmarkRunDisplayCount;
       displayUrlParams = '&display_count=' + benchmarkRunDisplayCount;
     } else {
-      displayCount = undefined;
       displayUrlParams = '';
     }
 


### PR DESCRIPTION
Displaycount variable which stores Benchmark run display count value. Displaycount is set to undefined and also not used any where in the code.