### PR TITLE
Sponsor data access improvements

### DIFF
--- a/app/models/sponsors.rb
+++ b/app/models/sponsors.rb
@@ -1,53 +1,11 @@
 class Sponsors
   class << self
     def all
-      sponsors.values.map { |sponsor| OpenStruct.new(sponsor) }
+      SponsorsData.values.map { |sponsor| OpenStruct.new(sponsor) }
     end
 
     def find(identifier)
-      OpenStruct.new(sponsors.fetch(identifier))
-    end
-
-    def sponsors
-      {
-        jolly_good_code:
-        {
-          name: 'Jolly Good Code',
-          desc: 'Modern craftsmen specialising in Agile practices and Ruby on Rails.',
-          link: 'http://www.jollygoodcode.com/',
-          class_name: 'sponsor-jolly-good-code',
-        },
-        discourse:
-        {
-          name: 'Discourse',
-          desc: 'Discourse is a simple, flat forum, where replies flow down the page in a line.',
-          link: 'http://www.discourse.org/',
-          class_name: 'sponsor-discourse'
-        },
-        rubytune:
-        {
-          name: 'Rubytune',
-          desc: 'Tune and troubleshoot rails apps.',
-          link: 'https://rubytune.com/',
-          class_name: 'sponsor-rubytune'
-        },
-        ruby_together:
-        {
-          name: 'Ruby Together',
-          desc: 'Ruby Together is dedicated to sustaining and improving the tools
-            and infrastructure of the Ruby programming language.',
-          link: 'https://rubytogether.org/',
-          class_name: 'sponsor-ruby-together'
-        },
-        bugsnag:
-        {
-          name: 'Bugsnag',
-          desc: "Detect and diagnose crashes in your applications.
-            Bugsnag's cross platform error monitoring helps you ship with confidence.",
-          link: 'https://bugsnag.com/',
-          class_name: 'sponsor-bugsnag'
-        }
-      }
+      OpenStruct.new(SponsorsData.fetch(identifier))
     end
   end
 end

--- a/config/initializers/load_settings.rb
+++ b/config/initializers/load_settings.rb
@@ -2,3 +2,5 @@ require 'ostruct'
 
 settings = YAML.load_file(Rails.root.join('config', 'settings.yml'))[Rails.env]
 AppSettings = OpenStruct.new(settings) unless defined?(AppSettings)
+
+::SponsorsData = YAML.load_file(Rails.root.join('config', 'sponsors.yml'))

--- a/config/sponsors.yml
+++ b/config/sponsors.yml
@@ -1,0 +1,25 @@
+jolly_good_code:
+  name: 'Jolly Good Code'
+  desc: 'Modern craftsmen specialising in Agile practices and Ruby on Rails.'
+  link: 'http://www.jollygoodcode.com/'
+  class_name: 'sponsor-jolly-good-code'
+discourse:
+  name: 'Discourse'
+  desc: 'Discourse is a simple, flat forum, where replies flow down the page in a line.'
+  link: 'http://www.discourse.org/'
+  class_name: 'sponsor-discourse'
+rubytune:
+  name: 'Rubytune'
+  desc: 'Tune and troubleshoot rails apps.'
+  link: 'https://rubytune.com/'
+  class_name: 'sponsor-rubytune'
+ruby_together:
+  name: 'Ruby Together'
+  desc: 'Ruby Together is dedicated to sustaining and improving the tools and infrastructure of the Ruby programming language.'
+  link: 'https://rubytogether.org/'
+  class_name: 'sponsor-ruby-together'
+bugsnag:
+  name: 'Bugsnag'
+  desc: "Detect and diagnose crashes in your applications. Bugsnag's cross platform error monitoring helps you ship with confidence."
+  link: 'https://bugsnag.com/'
+  class_name: 'sponsor-bugsnag'

--- a/test/acceptance/sponsors_test.rb
+++ b/test/acceptance/sponsors_test.rb
@@ -1,0 +1,23 @@
+require 'acceptance/test_helper'
+
+class SponsorsTest < AcceptanceTest
+  test "should display same number of sponsors" do
+    visit root_path
+    click_link "Sponsors", match: :first
+
+    assert page.has_content?(I18n.t("static_pages.sponsors.title"))
+
+    sponsors_count = all(".row .sponsor-row").count
+    assert_equal SponsorsData.count, sponsors_count
+  end
+
+  test "should have all sponsor names" do
+    if SponsorsData.count > 0
+      visit root_path
+      click_link "Sponsors", match: :first
+      SponsorsData.values.each do |sponsor|
+        assert page.has_content?(sponsor[:name])
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR stores sponsors data in YAML file and loads file at application load time. Changes scope of sponsors method to private.

As initializer file is changed server need to be restarted to view updated changes.