### PR TITLE
Add left right / arrow keys with bootstrap

### DIFF
--- a/app/assets/javascripts/initialize.js
+++ b/app/assets/javascripts/initialize.js
@@ -53,4 +53,37 @@ $(document).on('ready page:load', function() {
       }
     });
   });
+
+  // add forward/backward arrow navigation on benchmark page
+
+  var opts = $('.result-types-form select.form-control#benchmark-options option');
+  var selected = $('.result-types-form select.form-control#benchmark-options');
+  var optsLength = $('.result-types-form select.form-control#benchmark-options option').length;
+  var optionIndex = 0;
+  $('.result-types-form .form-group .input-group button#forward-arrow').click(function() {
+    selected.children().removeAttr('selected');
+    if ((optionIndex + 1) % optsLength == 0) {
+      optionIndex = 1;
+    }
+    else {
+      optionIndex = optionIndex + 1;
+    }
+    selected.children().eq(optionIndex).attr('selected', 'selected');
+    selected.val(selected.children().eq(optionIndex).val())
+    selected.change();
+  });
+
+  $('.result-types-form .form-group .input-group button#backward-arrow').click(function() {
+    selected.children().removeAttr('selected');
+    if ((optionIndex - 1) % optsLength <= 0) {
+      optionIndex = 2;
+    }
+    else {
+      optionIndex = optionIndex - 1;
+    }
+    selected.children().eq(optionIndex).attr('selected', 'selected');
+    selected.val(selected.children().eq(optionIndex).val())
+    selected.change();
+  });
+
 });

--- a/app/views/repos/_form.html.haml
+++ b/app/views/repos/_form.html.haml
@@ -1,8 +1,11 @@
 = form_tag form_path, role: 'form', method: :get, class: 'result-types-form form-inline', data: { organization_name: @organization.name, repo_name: @repo.name, name: name } do
   .form-group
     .input-group
+      %button.btn.btn-default#backward-arrow{"aria-label" => "Step backward", :type => "button"}
+        %span.glyphicon.glyphicon-step-backward{"aria-hidden" => "true"}
+    .input-group
       .input-group-addon= t('repos.benchmark_types')
-      %select.form-control
+      %select.form-control#benchmark-options
         %option{ value: "", selected: @form_result_type.blank? || @form, disabled: true }
           = t('repos.select_benchmark')
 
@@ -10,6 +13,9 @@
           %option{ value: category_name, selected: (@form_result_type == category_name) }
             = category_name
 
+    .input-group
+      %button.btn.btn-default#forward-arrow{"aria-label" => "Step forward", :type => "button"}
+        %span.glyphicon.glyphicon-step-forward{"aria-hidden" => "true"}
     - if name == 'commits'
       .input-group
         .input-group-addon= t('repos.show.show_last')

--- a/test/acceptance/view_benchmark_graphs_test.rb
+++ b/test/acceptance/view_benchmark_graphs_test.rb
@@ -120,10 +120,8 @@ class ViewBenchmarkGraphsTest < AcceptanceTest
     bm_type3 = create(:benchmark_type, repo: repo, category: 'c')
 
     visit repo_path(organization_name: org.name, repo_name: repo.name)
-
     within "form" do
-      list = page.first('.input-group').all('option')
-
+      list = page.find('.input-group select.form-control#benchmark-options').all('option')
       assert_equal(list.map(&:value), ["", 'b', 'c', 'd'])
     end
   end


### PR DESCRIPTION
- Toggle between benchmark options with glypicon arrows
- Addresses #78 

![rubybench long running ruby benchmark](https://cloud.githubusercontent.com/assets/777964/17841041/fe11bf9a-67c8-11e6-8753-ef78e82aa5d7.png)
