### PR TITLE
Fix 'view-benchmark-graph-test.rb' timing out

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -42,6 +42,7 @@ group :test do
   gem 'minitest-stub-const'
   gem 'factory_girl_rails'
   gem 'database_cleaner'
+  gem 'capybara-screenshot'
 end
 
 group :production, :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -65,6 +65,9 @@ GEM
       rack (>= 1.0.0)
       rack-test (>= 0.5.4)
       xpath (~> 2.0)
+    capybara-screenshot (1.0.14)
+      capybara (>= 1.0, < 3)
+      launchy
     celluloid (0.17.3)
       celluloid-essentials
       celluloid-extras
@@ -286,6 +289,7 @@ DEPENDENCIES
   bullet
   byebug
   capybara (= 2.7)
+  capybara-screenshot
   coffee-rails
   database_cleaner
   factory_girl_rails

--- a/test/acceptance/test_helper.rb
+++ b/test/acceptance/test_helper.rb
@@ -8,7 +8,7 @@ class AcceptanceTest < ActionDispatch::IntegrationTest
 
   self.use_transactional_tests = false
 
-  DatabaseCleaner.strategy = :truncation
+  DatabaseCleaner.strategy = :deletion
   setup { DatabaseCleaner.start }
   teardown  { DatabaseCleaner.clean }
 end

--- a/test/acceptance/view_benchmark_graphs_test.rb
+++ b/test/acceptance/view_benchmark_graphs_test.rb
@@ -1,8 +1,8 @@
 require 'acceptance/test_helper'
 
 class ViewBenchmarkGraphsTest < AcceptanceTest
+  include Capybara::Screenshot::MiniTestPlugin
   setup do
-    skip("Tests keep timing out for some reason")
     require_js
     Net::HTTP.stubs(:get).returns("def abc\n  puts haha\nend")
   end
@@ -11,230 +11,234 @@ class ViewBenchmarkGraphsTest < AcceptanceTest
     reset_driver
   end
 
-  test "User should be able to view long running benchmark graphs" do
-    repo = create(:repo)
-    org = repo.organization
-    benchmark_type = create(:benchmark_type, repo: repo)
-    commit = create(:commit, repo: repo)
-    benchmark_run = create(
-      :commit_benchmark_run, benchmark_type: benchmark_type, initiator: commit
-    )
-    benchmark_result_type = benchmark_run.benchmark_result_type
-    memory_benchmark_result_type = create(
-      :benchmark_result_type, name: 'Memory', unit: 'Kilobytes'
-    )
+  DatabaseCleaner.cleaning do
+    test "User should be able to view long running benchmark graphs" do
+        repo = create(:repo)
+        org = repo.organization
+        benchmark_type = create(:benchmark_type, repo: repo)
+        commit = create(:commit, repo: repo)
+        benchmark_run = create(
+          :commit_benchmark_run, benchmark_type: benchmark_type, initiator: commit
+        )
+        benchmark_result_type = benchmark_run.benchmark_result_type
+        memory_benchmark_result_type = create(
+          :benchmark_result_type, name: 'Memory', unit: 'Kilobytes'
+        )
 
-    create(:commit_benchmark_run,
-      initiator: commit, benchmark_type: benchmark_type,
-      benchmark_result_type: memory_benchmark_result_type
-    )
+        create(:commit_benchmark_run,
+          initiator: commit, benchmark_type: benchmark_type,
+          benchmark_result_type: memory_benchmark_result_type
+        )
 
-    visit repo_path(organization_name: org.name, repo_name: repo.name)
+        visit repo_path(organization_name: org.name, repo_name: repo.name)
 
-    assert page.has_content?(
-      I18n.t('repos.show.title', repo_name: repo.title)
-    )
+        assert page.has_content?(
+          I18n.t('repos.show.title', repo_name: repo.title)
+        )
 
-    assert_text :all, I18n.t('repos.show.select_benchmark')
+        assert_text :all, I18n.t('repos.show.select_benchmark')
 
-    within "form" do
-      select(benchmark_type.category)
+        within "form" do
+          select(benchmark_type.category)
+        end
+
+        within ".chart .highcharts-container .highcharts-yaxis-title",
+          match: :first do
+
+          assert page.has_content?(benchmark_result_type.unit)
+        end
+
+        assert(
+          all(".chart .highcharts-container .highcharts-yaxis-title")
+            .last
+            .has_content?(memory_benchmark_result_type.unit)
+        )
+
+        within ".highcharts-xaxis-labels", match: :first do
+          assert_equal commit.created_at.strftime("%Y-%m-%d"),
+            find('text').text
+        end
+
+        assert_equal(
+          URI.parse(page.current_url).request_uri,
+          "/#{org.name}" \
+          "/#{repo.name}/commits?result_type=" \
+          "#{benchmark_type.category}&display_count=#{BenchmarkRun::DEFAULT_PAGINATE_COUNT}"
+        )
     end
 
-    within ".chart .highcharts-container .highcharts-yaxis-title",
-      match: :first do
+    test "User should be able to see long running benchmark graph even without
+      memory benchmarks".squish do
 
-      assert page.has_content?(benchmark_result_type.unit)
+      benchmark_run = create(:commit_benchmark_run)
+      benchmark_type = benchmark_run.benchmark_type
+      repo = benchmark_type.repo
+      org = repo.organization
+      benchmark_run_category_humanize = benchmark_type.category.humanize
+
+      visit repo_path(organization_name: org.name, repo_name: repo.name)
+
+      within "form" do
+        select(benchmark_type.category)
+      end
+
+      assert page.has_css?(".chart .highcharts-container")
+      assert page.has_content?("#{benchmark_run_category_humanize} Graph")
+      assert_not page.has_content?("#{benchmark_run_category_humanize} memory Graph")
     end
 
-    assert(
-      all(".chart .highcharts-container .highcharts-yaxis-title")
-        .last
-        .has_content?(memory_benchmark_result_type.unit)
-    )
+    test "User should be able to select number of benchmark runs to display
+      for long running benchmark graphs" do
 
-    within ".highcharts-xaxis-labels", match: :first do
-      assert_equal commit.created_at.strftime("%Y-%m-%d"),
-        find('text').text
+      benchmark_type = create(:benchmark_type)
+      repo = benchmark_type.repo
+      org = repo.organization
+      benchmark_result_type = create(:benchmark_result_type)
+
+      30.times do
+        create(
+          :commit_benchmark_run, benchmark_type: benchmark_type,
+          benchmark_result_type: benchmark_result_type
+        )
+      end
+
+      visit repo_path(organization_name: org.name, repo_name: repo.name)
+
+      within "form" do
+        select(benchmark_type.category)
+      end
+
+      assert assert_selector(".highcharts-markers path", count: 30)
+
+      select 20, from: "benchmark_run_display_count"
+
+      assert assert_selector(".highcharts-markers path", count: 20)
+
     end
 
-    assert_equal(
-      URI.parse(page.current_url).request_uri,
-      "/#{org.name}" \
-      "/#{repo.name}/commits?result_type=" \
-      "#{benchmark_type.category}&display_count=#{BenchmarkRun::DEFAULT_PAGINATE_COUNT}"
-    )
-  end
+    test "User should see benchmark type categories as sorted" do
+      repo = create(:repo)
+      org = repo.organization
+      bm_type = create(:benchmark_type, repo: repo, category: 'd')
+      bm_type2 = create(:benchmark_type, repo: repo, category: 'b')
+      bm_type3 = create(:benchmark_type, repo: repo, category: 'c')
 
-  test "User should be able to see long running benchmark graph even without
-    memory benchmarks".squish do
+      visit repo_path(organization_name: org.name, repo_name: repo.name)
 
-    benchmark_run = create(:commit_benchmark_run)
-    benchmark_type = benchmark_run.benchmark_type
-    repo = benchmark_type.repo
-    org = repo.organization
-    benchmark_run_category_humanize = benchmark_type.category.humanize
+      within "form" do
+        list = page.first('.input-group').all('option')
 
-    visit repo_path(organization_name: org.name, repo_name: repo.name)
-
-    within "form" do
-      select(benchmark_type.category)
+        assert_equal(list.map(&:value), ["", 'b', 'c', 'd'])
+      end
     end
 
-    assert page.has_css?(".chart .highcharts-container")
-    assert page.has_content?("#{benchmark_run_category_humanize} Graph")
-    assert_not page.has_content?("#{benchmark_run_category_humanize} memory Graph")
-  end
+    test "User should be able to view releases benchmark graphs" do
+      repo = create(:repo)
+      org = repo.organization
+      benchmark_type = create(:benchmark_type, repo: repo)
+      release = create(:release, repo: repo)
+      bm_run = create(:release_benchmark_run, benchmark_type: benchmark_type, initiator: release)
+      benchmark_result_type = bm_run.benchmark_result_type
+      memory_benchmark_result_type = create(:benchmark_result_type, name: 'Memory', unit: 'rss')
 
-  test "User should be able to select number of benchmark runs to display
-    for long running benchmark graphs" do
+      create(:release_benchmark_run,
+        initiator: release, benchmark_type: benchmark_type,
+        benchmark_result_type: memory_benchmark_result_type
+      )
 
-    benchmark_type = create(:benchmark_type)
-    repo = benchmark_type.repo
-    org = repo.organization
-    benchmark_result_type = create(:benchmark_result_type)
-    3.times do
-      create(
-        :commit_benchmark_run, benchmark_type: benchmark_type,
-        benchmark_result_type: benchmark_result_type
+      visit releases_repo_path(organization_name: org.name, repo_name: repo.name)
+
+      assert page.has_content?(
+        I18n.t('repos.show_releases.title', repo_name: repo.title)
+      )
+
+      assert_text :all, I18n.t('repos.show.select_benchmark')
+
+      within "form" do
+        select(benchmark_type.category)
+      end
+
+      within ".release-chart .highcharts-container .highcharts-yaxis-title",
+        match: :first do
+
+        assert page.has_content?(benchmark_result_type.unit)
+      end
+
+      assert(
+        all(".release-chart .highcharts-container .highcharts-yaxis-title")
+          .last
+          .has_content?(memory_benchmark_result_type.unit)
+      )
+
+      assert_equal(
+        URI.parse(page.current_url).request_uri,
+        "/#{org.name}" \
+        "/#{repo.name}/releases?result_type=#{benchmark_type.category}"
       )
     end
 
-    BenchmarkRun.stub_const(:PAGINATE_COUNT, [1, 3]) do
-      BenchmarkRun.stub_const(:DEFAULT_PAGINATE_COUNT, 1) do
-        visit repo_path(organization_name: org.name, repo_name: repo.name, result_type: benchmark_type.category)
+    test "User should not be able to view releases memory benchmark graph if it
+      does not exist".squish do
 
-        assert assert_selector(".highcharts-markers path", count: 1)
+      repo = create(:repo)
+      org = repo.organization
+      benchmark_type = create(:benchmark_type, repo: repo)
+      release = create(:release, repo: repo)
+      benchmark_run = create(:release_benchmark_run,
+        benchmark_type: benchmark_type,
+        initiator: release
+      )
 
-        select 3, from: "benchmark_run_display_count"
+      create(:release_benchmark_run,
+        benchmark_type: benchmark_type,
+        initiator: release,
+        created_at: Time.zone.now - 1.day
+      )
 
-        assert assert_selector(".highcharts-markers path", count: 3)
+      visit releases_repo_path(organization_name: org.name, repo_name: repo.name)
+
+      assert page.has_content?(
+        I18n.t('repos.show_releases.title', repo_name: repo.title)
+      )
+
+      assert_text :all, I18n.t('repos.show.select_benchmark')
+
+      within "form" do
+        select(benchmark_type.category)
       end
-    end
-  end
 
-  test "User should see benchmark type categories as sorted" do
-    repo = create(:repo)
-    org = repo.organization
-    bm_type = create(:benchmark_type, repo: repo, category: 'd')
-    bm_type2 = create(:benchmark_type, repo: repo, category: 'b')
-    bm_type3 = create(:benchmark_type, repo: repo, category: 'c')
+      assert page.has_css?(".release-chart .highcharts-container")
+      assert_not page.has_css?(".release-chart.memory .highcharts-container")
+      assert page.has_content?("def abc")
 
-    visit repo_path(organization_name: org.name, repo_name: repo.name)
+      benchmark_run_category_humanize = benchmark_type.category.humanize
 
-    within "form" do
-      list = page.first('.input-group').all('option')
+      assert page.has_content?("#{benchmark_run_category_humanize} Graph")
+      assert_not page.has_content?("#{benchmark_run_category_humanize} memory Graph")
+      assert page.has_content?("#{benchmark_run_category_humanize} Script")
 
-      assert_equal(list.map(&:value), ["", 'b', 'c', 'd'])
-    end
-  end
-
-  test "User should be able to view releases benchmark graphs" do
-    repo = create(:repo)
-    org = repo.organization
-    benchmark_type = create(:benchmark_type, repo: repo)
-    release = create(:release, repo: repo)
-    bm_run = create(:release_benchmark_run, benchmark_type: benchmark_type, initiator: release)
-    benchmark_result_type = bm_run.benchmark_result_type
-    memory_benchmark_result_type = create(:benchmark_result_type, name: 'Memory', unit: 'rss')
-
-    create(:release_benchmark_run,
-      initiator: release, benchmark_type: benchmark_type,
-      benchmark_result_type: memory_benchmark_result_type
-    )
-
-    visit releases_repo_path(organization_name: org.name, repo_name: repo.name)
-
-    assert page.has_content?(
-      I18n.t('repos.show_releases.title', repo_name: repo.title)
-    )
-
-    assert_text :all, I18n.t('repos.show.select_benchmark')
-
-    within "form" do
-      select(benchmark_type.category)
+      assert_equal(
+        URI.parse(page.current_url).request_uri,
+        "/#{org.name}" \
+        "/#{repo.name}/releases?result_type=#{benchmark_type.category}"
+      )
     end
 
-    within ".release-chart .highcharts-container .highcharts-yaxis-title",
-      match: :first do
+    test "User should see the right message for benchmark types with no
+      benchmark runs".squish do
 
-      assert page.has_content?(benchmark_result_type.unit)
+      repo = create(:repo)
+      org = repo.organization
+      category = create(:benchmark_type, repo: repo).category
+
+      visit releases_repo_path(organization_name: org.name, repo_name: repo.name)
+
+      within "form" do
+        select(category)
+      end
+
+      assert_not page.has_css?(".release-chart .highcharts-container")
+      assert page.has_content?(I18n.t("repos.no_results", category: category))
     end
-
-    assert(
-      all(".release-chart .highcharts-container .highcharts-yaxis-title")
-        .last
-        .has_content?(memory_benchmark_result_type.unit)
-    )
-
-    assert_equal(
-      URI.parse(page.current_url).request_uri,
-      "/#{org.name}" \
-      "/#{repo.name}/releases?result_type=#{benchmark_type.category}"
-    )
-  end
-
-  test "User should not be able to view releases memory benchmark graph if it
-    does not exist".squish do
-
-    repo = create(:repo)
-    org = repo.organization
-    benchmark_type = create(:benchmark_type, repo: repo)
-    release = create(:release, repo: repo)
-    benchmark_run = create(:release_benchmark_run,
-      benchmark_type: benchmark_type,
-      initiator: release
-    )
-
-    create(:release_benchmark_run,
-      benchmark_type: benchmark_type,
-      initiator: release,
-      created_at: Time.zone.now - 1.day
-    )
-
-    visit releases_repo_path(organization_name: org.name, repo_name: repo.name)
-
-    assert page.has_content?(
-      I18n.t('repos.show_releases.title', repo_name: repo.title)
-    )
-
-    assert_text :all, I18n.t('repos.show.select_benchmark')
-
-    within "form" do
-      select(benchmark_type.category)
-    end
-
-    assert page.has_css?(".release-chart .highcharts-container")
-    assert_not page.has_css?(".release-chart.memory .highcharts-container")
-    assert page.has_content?("def abc")
-
-    benchmark_run_category_humanize = benchmark_type.category.humanize
-
-    assert page.has_content?("#{benchmark_run_category_humanize} Graph")
-    assert_not page.has_content?("#{benchmark_run_category_humanize} memory Graph")
-    assert page.has_content?("#{benchmark_run_category_humanize} Script")
-
-    assert_equal(
-      URI.parse(page.current_url).request_uri,
-      "/#{org.name}" \
-      "/#{repo.name}/releases?result_type=#{benchmark_type.category}"
-    )
-  end
-
-  test "User should see the right message for benchmark types with no
-    benchmark runs".squish do
-
-    repo = create(:repo)
-    org = repo.organization
-    category = create(:benchmark_type, repo: repo).category
-
-    visit releases_repo_path(organization_name: org.name, repo_name: repo.name)
-
-    within "form" do
-      select(category)
-    end
-
-    assert_not page.has_css?(".release-chart .highcharts-container")
-    assert page.has_content?(I18n.t("repos.no_results", category: category))
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -2,6 +2,7 @@ ENV['RAILS_ENV'] ||= 'test'
 require File.expand_path('../../config/environment', __FILE__)
 require 'rails/test_help'
 require 'mocha/mini_test'
+require 'capybara-screenshot/minitest'
 
 Dir["#{Rails.root}/test/support/**/*"].each { |file| require file }
 


### PR DESCRIPTION
This change fixes the issue of `view-benchmark-graph-test.rb` timing out:
- Add 'capybara-screenshot'
- Fix database_cleaner to reset the DB properly
- Fix timimg out of "User should be able to select number of benchmark runs to display for long running benchmark graphs"