### PR TITLE
Possible typo in database seed benchmark name

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -72,8 +72,8 @@ end
     environment: 'ruby 2.2.0dev',
     initiator_id: release.id,
     initiator_type: 'Release',
-    benchmark_type_id: ab_bench.id,
-    benchmark_result_type_id: ab_benchmark_result_type.id
+    benchmark_type_id: ao_bench.id,
+    benchmark_result_type_id: ao_benchmark_result_type.id
   )
 
   BenchmarkRun.create!(
@@ -81,7 +81,7 @@ end
     environment: 'ruby 2.2.0dev',
     initiator_id: release.id,
     initiator_type: 'Release',
-    benchmark_type_id: ao_bench.id,
-    benchmark_result_type_id: ao_benchmark_result_type.id
+    benchmark_type_id: ab_bench.id,
+    benchmark_result_type_id: ab_benchmark_result_type.id
   )
 end


### PR DESCRIPTION
In development, running `bundle exec rake db:setup` with the current `db/seeds.rb` causes the following (a result from `ao_bench` is displayed in the graph for `ab_bench`):

![image](https://cloud.githubusercontent.com/assets/15824429/22389242/8f314052-e4b2-11e6-8052-7a32486427a7.png)

The reverse (a result from `ab_bench` is displayed in the graph for `ao_bench`) is true as well.  
This PR resolves this problem, as follows:

![image](https://cloud.githubusercontent.com/assets/15824429/22389547/141af5be-e4b4-11e6-8562-2761cdaedc13.png)

If this is intended behaviour, then feel free to ignore this PR.
