### PR TITLE
Fix footer links so that they're centered

### DIFF
--- a/app/assets/stylesheets/modules/_footer.scss
+++ b/app/assets/stylesheets/modules/_footer.scss
@@ -10,6 +10,7 @@
   }
   .footer-nav-links {
     text-align: center;
+    padding-left: 0;
     li {
       display: inline-block;
       font-weight: $bold;


### PR DESCRIPTION
The footer links on each page were off-centre. This centres them again.

before:
![image](https://cloud.githubusercontent.com/assets/15824429/22712768/02e62ff4-ed54-11e6-89d6-0904eb81367e.png)

after:
![image](https://cloud.githubusercontent.com/assets/15824429/22712775/090b7f60-ed54-11e6-9345-b4665d247aea.png)
