### PR TITLE
Install phantomJS 2.1.1 manually to fix travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: ruby
 cache:
   directories:
     - vendor/bundle
+    - travis_phantomjs
 sudo: false
 rvm:
   - "2.3.3"
@@ -12,6 +13,12 @@ before_script:
   - bundle exec rake db:create
   - bundle exec rake db:migrate
 before_install:
+  - "export PATH=$PWD/travis_phantomjs/phantomjs-2.1.1-linux-x86_64/bin:$PATH"
+  - if [ $(phantomjs --version) != '2.1.1' ]; then 
+      rm -rf $PWD/travis_phantomjs; mkdir -p $PWD/travis_phantomjs;
+      wget https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-2.1.1-linux-x86_64.tar.bz2 -O $PWD/travis_phantomjs/phantomjs-2.1.1-linux-x86_64.tar.bz2;
+      tar -xvf $PWD/travis_phantomjs/phantomjs-2.1.1-linux-x86_64.tar.bz2 -C $PWD/travis_phantomjs; 
+    fi
   - "export DISPLAY=:99.0"
   - "sh -e /etc/init.d/xvfb start"
 script: bundle exec rake test


### PR DESCRIPTION
This fixes the travis build, which kept saying to upgrade to PhantomJS >= 2.1.1

Solution taken from [here](https://github.com/travis-ci/travis-ci/issues/3225#issuecomment-200965782)