### PR TITLE
Fix commits chart data

### DIFF
--- a/app/assets/javascripts/modules/chart.js.erb
+++ b/app/assets/javascripts/modules/chart.js.erb
@@ -15,6 +15,9 @@ var drawChart = function(chartClass) {
   $(chartClass).each(function() {
     $this = $(this);
 
+    escaped = $this.attr('data-categories');
+    $this.attr('data-categories', escaped.replace(/\\#/g, "#"));
+
     if($this.length) {
       $this.highcharts({
         chart: {

--- a/app/helpers/charts_helper.rb
+++ b/app/helpers/charts_helper.rb
@@ -10,7 +10,7 @@ module ChartsHelper
   # }
   #
   # and this function turns it into:
-  # Commit: b6589fc
+  # Commit Sha: b6589fc
   # Commit Date: 2017-02-23T16:20:13.338Z
   # Commit Message: fix something
   # ruby 2.2.0dev


### PR DESCRIPTION
Commit messages containing ruby like string interpolation syntax were causing problem with chart categories and tooltips.

On ruby side messages are being received escaped `\#{ ... }` which caused error in javascript on `JSON.parse`. So before drawing chart I removed those escapements.

I struggled a bit with this but got help https://stackoverflow.com/questions/44630300/why-jquery-cant-parse-inside-array-string/44630468#44630468