### PR TITLE
Disable StrictHostKeyChecking on ssh

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,10 +34,9 @@ after_success:
       chmod 600 /tmp/deploy_rsa;
       ssh-add /tmp/deploy_rsa;
 
-      ssh root@$DEPLOY_HOST ./deploy;
+      ssh -o StrictHostKeyChecking=no root@$DEPLOY_HOST ./deploy;
     fi
 addons:
   postgresql: "9.3"
-  ssh_known_hosts: $DEPLOY_HOST
 services:
   - redis-server


### PR DESCRIPTION
Adding deploy server address can't be added to ssh known hosts via travis addons, because it is being executed before exporting secret environment variables (which is needed to read `$DEPLOY_HOST`).