### PR TITLE
Use minitest-rails-capybara for acceptance tests

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -39,7 +39,6 @@ group :test do
   gem 'mocha'
   gem 'vcr'
   gem 'webmock'
-  gem 'capybara', '2.7'
   gem 'launchy'
   gem 'selenium-webdriver', '~> 2.53'
   gem 'poltergeist'
@@ -47,6 +46,7 @@ group :test do
   gem 'factory_girl_rails'
   gem 'database_cleaner'
   gem 'capybara-screenshot'
+  gem 'minitest-rails-capybara'
 end
 
 group :production, :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -147,6 +147,20 @@ GEM
     mime-types-data (3.2016.0521)
     mini_portile2 (2.1.0)
     minitest (5.9.1)
+    minitest-capybara (0.8.2)
+      capybara (~> 2.2)
+      minitest (~> 5.0)
+      rake
+    minitest-metadata (0.6.0)
+      minitest (>= 4.7, < 6.0)
+    minitest-rails (3.0.0)
+      minitest (~> 5.8)
+      railties (~> 5.0)
+    minitest-rails-capybara (3.0.1)
+      capybara (~> 2.7)
+      minitest-capybara (~> 0.8)
+      minitest-metadata (~> 0.6)
+      minitest-rails (~> 3.0)
     minitest-stub-const (0.5)
     mocha (1.2.1)
       metaclass (~> 0.0.1)
@@ -317,7 +331,6 @@ DEPENDENCIES
   bugsnag
   bullet
   byebug
-  capybara (= 2.7)
   capybara-screenshot
   coffee-rails
   database_cleaner
@@ -329,6 +342,7 @@ DEPENDENCIES
   jquery-ui-rails
   launchy
   logster
+  minitest-rails-capybara
   minitest-stub-const
   mocha
   msgpack
@@ -361,4 +375,4 @@ DEPENDENCIES
   webmock
 
 BUNDLED WITH
-   1.14.6
+   1.15.1

--- a/test/acceptance/sponsors_test.rb
+++ b/test/acceptance/sponsors_test.rb
@@ -2,8 +2,6 @@ require 'acceptance/test_helper'
 
 class SponsorsTest < AcceptanceTest
   test 'should display same number of sponsors' do
-    skip('Sponsors test is flaky')
-
     visit root_path
 
     within 'nav' do
@@ -15,8 +13,6 @@ class SponsorsTest < AcceptanceTest
   end
 
   test 'should have all sponsor names' do
-    skip('Sponsors test is flaky')
-
     if SponsorsData.count > 0
       visit root_path
       click_link 'Sponsors', match: :first

--- a/test/acceptance/test_helper.rb
+++ b/test/acceptance/test_helper.rb
@@ -4,7 +4,6 @@ require 'minitest/rails/capybara'
 Dir['./test/acceptance/support/**/*'].each { |file| require file }
 
 class AcceptanceTest < Capybara::Rails::TestCase
-  include Capybara::DSL
   include Capybara::JavaScriptDriver
   include Capybara::Screenshot::MiniTestPlugin
 

--- a/test/acceptance/test_helper.rb
+++ b/test/acceptance/test_helper.rb
@@ -1,8 +1,9 @@
 require './test/test_helper'
+require 'minitest/rails/capybara'
 
 Dir['./test/acceptance/support/**/*'].each { |file| require file }
 
-class AcceptanceTest < ActionDispatch::IntegrationTest
+class AcceptanceTest < Capybara::Rails::TestCase
   include Capybara::DSL
   include Capybara::JavaScriptDriver
   include Capybara::Screenshot::MiniTestPlugin


### PR DESCRIPTION
Acceptance tests were flaky for some time due to possible race conditions. 

I found out that Capybara shouldn't be used with integration test (`ActionDispatch::IntegrationTest`), therefore I replaced it with `Capybara::Rails::TestCase`.
http://blowmage.com/minitest-rails-capybara/

It looks like this recovered test suite - I've run it 10 times in for loop and no flaky error was raised.

