### PR TITLE
Manually run only latest commit

### DIFF
--- a/app/services/commits_runner.rb
+++ b/app/services/commits_runner.rb
@@ -1,16 +1,8 @@
 class CommitsRunner
   def self.run(commits, pattern = '')
-    commits.each do |commit|
-      if valid?(commit)
-        create(commit)
-
-        BenchmarkPool.enqueue(
-          commit[:repo].name,
-          commit[:sha],
-          include_patterns: pattern
-        )
-      end
-    end
+    commits.select { |commit| valid?(commit) }
+           .each { |commit| create_and_run(commit, pattern) }
+           .count
   end
 
   private
@@ -19,12 +11,18 @@ class CommitsRunner
     !Commit.merge_or_skip_ci?(commit[:message]) && Commit.valid_author?(commit[:author_name])
   end
 
-  def self.create(commit)
+  def self.create_and_run(commit, pattern)
     Commit.find_or_create_by!(sha1: commit[:sha]) do |c|
       c.url = commit[:url]
       c.message = commit[:message]
       c.repo_id = commit[:repo].id
       c.created_at = commit[:created_at]
     end
+
+    BenchmarkPool.enqueue(
+      commit[:repo].name,
+      commit[:sha],
+      include_patterns: pattern
+    )
   end
 end

--- a/app/services/manual_runner.rb
+++ b/app/services/manual_runner.rb
@@ -1,5 +1,5 @@
 class ManualRunner
-  OPTIONS = ['20', '100', '200', '500', '750', '2000']
+  OPTIONS = ['1', '20', '100', '200', '500', '750', '2000']
 
   def initialize(repo)
     raise "Repo doesn't exist" unless Repo.exists?(repo.id)
@@ -8,20 +8,24 @@ class ManualRunner
   end
 
   def run_last(commits_count, pattern: '')
-    run_paginated(commits_count, pattern: pattern)
+    if commits_count < 100
+      run_commits(per_page: commits_count, pattern: pattern)
+    else
+      run_paginated(commits_count, pattern: pattern)
+    end
   end
 
   private
 
   def run_paginated(commits_count, page: 1, pattern: '')
     unless (commits_count <= 0)
-      count_run = run_commits(page, pattern: pattern)
+      count_run = run_commits(page: page, pattern: pattern)
       run_paginated(commits_count - count_run, page: page + 1, pattern: pattern)
     end
   end
 
-  def run_commits(page, pattern: '')
-    fetched_commits = @octokit.commits("#{@repo.organization.name}/#{@repo.name}", per_page: 100, page: page)
+  def run_commits(page: 1, per_page: 100, pattern: '')
+    fetched_commits = @octokit.commits("#{@repo.organization.name}/#{@repo.name}", per_page: per_page, page: page)
     formatted_commits = format_commits(fetched_commits)
     CommitsRunner.run(formatted_commits, pattern)
 

--- a/app/services/manual_runner.rb
+++ b/app/services/manual_runner.rb
@@ -28,8 +28,6 @@ class ManualRunner
     fetched_commits = @octokit.commits("#{@repo.organization.name}/#{@repo.name}", per_page: per_page, page: page)
     formatted_commits = format_commits(fetched_commits)
     CommitsRunner.run(formatted_commits, pattern)
-
-    fetched_commits.count
   end
 
   def format_commits(commits)

--- a/test/services/manual_runner_test.rb
+++ b/test/services/manual_runner_test.rb
@@ -13,7 +13,7 @@ class ManualRunnerTest < ActiveSupport::TestCase
     end
   end
 
-  test 'run_last' do
+  test 'run last 200 commits' do
     organization = create(:organization, name: 'jeremyevans')
     repo = create(:repo, name: 'sequel', organization: organization)
 
@@ -26,10 +26,34 @@ class ManualRunnerTest < ActiveSupport::TestCase
         assert commit[:repo]
         assert commit[:author_name]
       end
+
+      assert 100, commits.count
     end
 
-    VCR.use_cassette('github') do
+    VCR.use_cassette('github 200 commits') do
       ManualRunner.new(repo).run_last(200)
+    end
+  end
+
+  test 'run last 20 commits' do
+    organization = create(:organization, name: 'jeremyevans')
+    repo = create(:repo, name: 'sequel', organization: organization)
+
+    CommitsRunner.expects(:run).times(1).with do |commits|
+      commits.each do |commit|
+        assert commit[:sha]
+        assert commit[:message]
+        assert commit[:url]
+        assert commit[:created_at]
+        assert commit[:repo]
+        assert commit[:author_name]
+      end
+
+      assert_equal 20, commits.count
+    end
+
+    VCR.use_cassette('github 20 commits') do
+      ManualRunner.new(repo).run_last(20)
     end
   end
 end

--- a/test/services/manual_runner_test.rb
+++ b/test/services/manual_runner_test.rb
@@ -17,7 +17,7 @@ class ManualRunnerTest < ActiveSupport::TestCase
     organization = create(:organization, name: 'jeremyevans')
     repo = create(:repo, name: 'sequel', organization: organization)
 
-    CommitsRunner.expects(:run).times(2).with do |commits|
+    CommitsRunner.expects(:run).times(2).returns(100).with do |commits|
       commits.each do |commit|
         assert commit[:sha]
         assert commit[:message]
@@ -39,7 +39,7 @@ class ManualRunnerTest < ActiveSupport::TestCase
     organization = create(:organization, name: 'jeremyevans')
     repo = create(:repo, name: 'sequel', organization: organization)
 
-    CommitsRunner.expects(:run).times(1).with do |commits|
+    CommitsRunner.expects(:run).times(1).returns(20).with do |commits|
       commits.each do |commit|
         assert commit[:sha]
         assert commit[:message]


### PR DESCRIPTION
There was a bug when running less than 100 latest commits. It was because of paginating 100 commits per page.

Now it's possible to run only latest or last 20 or 50 commits.