### PR TITLE
Replace bugsnag with Sentry

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -59,7 +59,7 @@ end
 group :production do
   gem 'rails_12factor'
   gem 'newrelic_rpm'
-  gem 'bugsnag'
+  gem 'sentry-raven'
 end
 gem 'nokogiri', '>= 1.6.8'
 gem 'rubyzip', '>= 1.2.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -56,7 +56,6 @@ GEM
     bootstrap_sb_admin_base_v2 (0.3.6)
       font-awesome-rails
       jquery-rails
-    bugsnag (5.0.1)
     builder (3.2.3)
     bullet (5.4.2)
       activesupport (>= 3.0.0)
@@ -273,6 +272,8 @@ GEM
       childprocess (~> 0.5)
       rubyzip (~> 1.0)
       websocket (~> 1.0)
+    sentry-raven (2.6.3)
+      faraday (>= 0.7.6, < 1.0)
     sidekiq (5.0.4)
       concurrent-ruby (~> 1.0)
       connection_pool (~> 2.2, >= 2.2.0)
@@ -328,7 +329,6 @@ DEPENDENCIES
   binding_of_caller
   bootstrap-sass
   bootstrap_sb_admin_base_v2
-  bugsnag
   bullet
   byebug
   capybara-screenshot
@@ -364,6 +364,7 @@ DEPENDENCIES
   rubyzip (>= 1.2.1)
   sass-rails
   selenium-webdriver (~> 2.53)
+  sentry-raven
   sidekiq
   sidetiq
   spring
@@ -374,4 +375,4 @@ DEPENDENCIES
   webmock
 
 BUNDLED WITH
-   1.15.1
+   1.15.3

--- a/config/initializers/bugsnag.rb
+++ b/config/initializers/bugsnag.rb
@@ -1,3 +1,0 @@
-if Rails.env.production?
-  Bugsnag.configure { |config| config.api_key = ENV['BUGSNAG_API_TOKEN'] }
-end

--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -1,0 +1,3 @@
+if Rails.env.production?
+  Raven.configure { |config| config.dsn = ENV['SENTRY_DSN'] }
+end


### PR DESCRIPTION
We benefit from Sentry Sponsored plan with unlimited members on projects.

I plan to set it up on ruby-bench-suite also to catch errors :tada: 