### PR TITLE
Fix flaky test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ cache:
     - test/vcr_cassettes
 sudo: false
 rvm:
-  - "2.3.3"
+  - "2.4.1"
 notifications:
   email: false
 bundler_args: --without development:production --deployment --retry=3 --jobs=3

--- a/Gemfile
+++ b/Gemfile
@@ -39,7 +39,7 @@ end
 group :test do
   gem 'mocha'
   gem 'vcr'
-  gem 'webmock'
+  gem 'webmock', '~> 3.0'
   gem 'launchy'
   gem 'selenium-webdriver', '~> 2.53'
   gem 'poltergeist'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -121,7 +121,7 @@ GEM
       activesupport (>= 4.2.0)
     haml (4.0.7)
       tilt
-    hashdiff (0.3.0)
+    hashdiff (0.3.6)
     highstock-rails (5.0.11)
       railties (>= 3.1)
     hitimes (1.2.4)
@@ -310,7 +310,7 @@ GEM
       raindrops (~> 0.7)
     uniform_notifier (1.10.0)
     vcr (3.0.3)
-    webmock (2.1.0)
+    webmock (3.0.1)
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff
@@ -372,7 +372,7 @@ DEPENDENCIES
   uglifier
   unicorn
   vcr
-  webmock
+  webmock (~> 3.0)
 
 BUNDLED WITH
-   1.15.3
+   1.15.4

--- a/test/models/benchmark_type_test.rb
+++ b/test/models/benchmark_type_test.rb
@@ -33,7 +33,7 @@ class BenchmarkTypeTest < ActiveSupport::TestCase
     groups.first.benchmark_types << benchmark_types.first(3)
     groups.second.benchmark_types << benchmark_types.last(3)
 
-    assert_equal benchmark_types.first.comparison_benchmark_types.to_a, benchmark_types[1..2]
-    assert_equal benchmark_types.third.comparison_benchmark_types.to_a, benchmark_types.first(2) + benchmark_types.last(2)
+    assert_matched_arrays benchmark_types.first.comparison_benchmark_types, benchmark_types[1..2]
+    assert_matched_arrays benchmark_types.third.comparison_benchmark_types, benchmark_types.first(2) + benchmark_types.last(2)
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -14,3 +14,13 @@ class ActiveSupport::TestCase
 end
 
 Sidekiq::Testing.fake!
+
+module MiniTest::Assertions
+  def assert_matched_arrays(expected, actual)
+    expected_array = expected.to_ary
+    assert_kind_of Array, expected_array
+    actual_array = actual.to_ary
+    assert_kind_of Array, actual_array
+    assert_equal expected_array.sort, actual_array.sort
+  end
+end


### PR DESCRIPTION
`test/models/benchmark_type_test.rb:29` was failing because of different ordered arrays. Added custom Minitest assertion for array matching.