### PR TITLE
Fix redis cache deletion

### DIFF
--- a/app/controllers/benchmark_runs_controller.rb
+++ b/app/controllers/benchmark_runs_controller.rb
@@ -33,7 +33,7 @@ class BenchmarkRunsController < APIController
     benchmark_run.validity = true
     benchmark_run.save!
 
-    $redis.keys("#{BenchmarkRun.charts_cache_key(benchmark_type, benchmark_result_type)}:*").each do |key|
+    $redis.keys("*#{BenchmarkRun.charts_cache_key(benchmark_type, benchmark_result_type)}*").each do |key|
       $redis.del(key)
     end
 

--- a/app/controllers/repos_controller.rb
+++ b/app/controllers/repos_controller.rb
@@ -213,7 +213,7 @@ class ReposController < ApplicationController
       @benchmark.benchmark_result_types.each do |benchmark_type|
         @cache_keys[benchmark_type] =
           if @comparing_benchmark.present?
-            "#{BenchmarkRun.charts_cache_key(@benchmark, benchmark_type)}:#{@display_count}:#{BenchmarkRun.charts_cache_key(@comparing_benchmark, benchmark_type)}"
+            "#{BenchmarkRun.charts_cache_key(@benchmark, benchmark_type)}:#{BenchmarkRun.charts_cache_key(@comparing_benchmark, benchmark_type)}"
           else
             "#{BenchmarkRun.charts_cache_key(@benchmark, benchmark_type)}:#{@display_count}"
           end


### PR DESCRIPTION
When new run is being saved for certain benchmark, we want to invalidate cache for both comparison charts.

For example -- when new run for `pg/scope_all` is received, we want to invalidate cache for both charts:

https://rubybench.org/ged/ruby-pg/commits?result_type=pg/scope_all&display_count=2000&compare_with=activerecord/postgres_scope_all

and

https://rubybench.org/rails/rails/commits?result_type=activerecord/postgres_scope_all&display_count=2000&compare_with=pg/scope_all