### PR TITLE
bundle update puma

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -192,7 +192,7 @@ GEM
       websocket-driver (>= 0.2.0)
     powerpack (0.1.1)
     public_suffix (2.0.4)
-    puma (3.6.0)
+    puma (3.11.4)
     rack (2.0.4)
     rack-mini-profiler (0.10.1)
       rack (>= 1.2.0)


### PR DESCRIPTION
As I'm using Ubuntu 18.04 which has OpenSSL 1.1.0, puma 3.6.0 couldn't be installed. So I want to upgrade puma's version to pass `bundle install`.