### PR TITLE
Fix chart builder logic for JIT

### DIFF
--- a/app/services/chart_builder.rb
+++ b/app/services/chart_builder.rb
@@ -37,6 +37,7 @@ class ChartBuilder
   end
 
   def build_columns
+    keys = @benchmark_runs.map { |run| run.result.keys }.flatten.uniq
     @benchmark_runs.each do |benchmark_run|
       if block_given?
         version = yield(benchmark_run)
@@ -44,9 +45,9 @@ class ChartBuilder
         @categories << version if version != @categories.last
       end
 
-      benchmark_run.result.each do |key, value|
+      keys.each do |key|
         @columns[key] ||= []
-        @columns[key] << value.to_f
+        @columns[key] << benchmark_run.result[key]&.to_f
       end
     end
 

--- a/test/services/chart_builder_test.rb
+++ b/test/services/chart_builder_test.rb
@@ -3,7 +3,7 @@ require 'test_helper'
 class ChartBuilderTest < ActiveSupport::TestCase
   test '#build_columns' do
     benchmark_run = create(:commit_benchmark_run, result: { 'some_time' => 5, 'some_other_time' => 5 })
-    other_benchmark_run = create(:commit_benchmark_run, result: { 'some_time' => 5, 'some_other_time' => 5 })
+    other_benchmark_run = create(:commit_benchmark_run, result: { 'some_time' => 5, 'some_other_time' => 5, 'jit_time' => 5 })
     chart_builder = ChartBuilder.new([benchmark_run, other_benchmark_run], benchmark_run.benchmark_result_type)
 
     chart_builder2 = chart_builder.build_columns do |benchmark_run|
@@ -19,7 +19,8 @@ class ChartBuilderTest < ActiveSupport::TestCase
     assert_equal(
       [
         { name: 'some_time', data: [benchmark_run.result['some_time'].to_f, other_benchmark_run.result['some_time'].to_f] },
-        { name: 'some_other_time', data: [benchmark_run.result['some_other_time'].to_f, other_benchmark_run.result['some_other_time'].to_f] }
+        { name: 'some_other_time', data: [benchmark_run.result['some_other_time'].to_f, other_benchmark_run.result['some_other_time'].to_f] },
+        { name: 'jit_time', data: [nil, other_benchmark_run.result['jit_time'].to_f] },
       ],
       chart_builder.columns
     )


### PR DESCRIPTION
## Problem
When using "Show the last 2000 Results", the JIT graph appears only in the commits which didn't have JIT.

![screenshot from 2018-06-27 00-32-42](https://user-images.githubusercontent.com/3138447/41923153-b3f73f7e-79a1-11e8-8723-4e8fa95bfcc5.png)
https://rubybench.org/ruby/ruby/commits?result_type=app_erb&display_count=2000

## Solution
Fill `nil` for the commits which don't have `*_jit` result in the chart.