### PR TITLE
Release benchmarks should also filter by repo_id so we don't get mixed results

### DIFF
--- a/app/controllers/repos_controller.rb
+++ b/app/controllers/repos_controller.rb
@@ -31,7 +31,7 @@ class ReposController < ApplicationController
     unless @benchmark.blank?
       @charts = ips_first(@benchmark.benchmark_result_types).map do |benchmark_result_type|
         benchmark_runs = BenchmarkRun.fetch_release_benchmark_runs(
-          @benchmark.category, benchmark_result_type
+          @benchmark, benchmark_result_type
         )
 
         next if benchmark_runs.empty?

--- a/app/models/benchmark_run.rb
+++ b/app/models/benchmark_run.rb
@@ -29,13 +29,15 @@ class BenchmarkRun < ApplicationRecord
       .limit(limit)
   }
 
-  scope :fetch_release_benchmark_runs, ->(form_result_type, benchmark_result_type) {
+  scope :fetch_release_benchmark_runs, ->(result_type, benchmark_result_type) {
     joins(:benchmark_type)
+      .joins("INNER JOIN releases ON releases.id = benchmark_runs.initiator_id")
       .includes(:initiator)
       .where(
-        benchmark_types: { category: form_result_type },
+        benchmark_types: { category: result_type.category },
         benchmark_result_type: benchmark_result_type,
         initiator_type: 'Release',
+        releases: { repo_id: result_type.repo_id },
         validity: true
       )
   }

--- a/app/models/benchmark_run.rb
+++ b/app/models/benchmark_run.rb
@@ -31,7 +31,7 @@ class BenchmarkRun < ApplicationRecord
 
   scope :fetch_release_benchmark_runs, ->(result_type, benchmark_result_type) {
     joins(:benchmark_type)
-      .joins("INNER JOIN releases ON releases.id = benchmark_runs.initiator_id")
+      .joins('INNER JOIN releases ON releases.id = benchmark_runs.initiator_id')
       .includes(:initiator)
       .where(
         benchmark_types: { category: result_type.category },

--- a/test/models/benchmark_run_test.rb
+++ b/test/models/benchmark_run_test.rb
@@ -42,7 +42,7 @@ class BenchmarkRunTest < ActiveSupport::TestCase
   end
 
   test '.fetch_release_benchmark_runs' do
-    script_url = "https://raw.githubusercontent.com/org/repo/master/script/bench.rb"
+    script_url = 'https://raw.githubusercontent.com/org/repo/master/script/bench.rb'
 
     ruby = create(:repo, name: 'ruby')
     rails = create(:repo, name: 'rails')
@@ -50,8 +50,8 @@ class BenchmarkRunTest < ActiveSupport::TestCase
     ruby_release = create(:release, repo: ruby, version: '2.6.2')
     rails_release = create(:release, repo: rails, version: '6.0.0')
 
-    ruby_benchmark_type = create(:benchmark_type, category: "discourse_home", repo: ruby, script_url: script_url)
-    rails_benchmark_type = create(:benchmark_type, category: "discourse_home", repo: rails, script_url: script_url)
+    ruby_benchmark_type = create(:benchmark_type, category: 'discourse_home', repo: ruby, script_url: script_url)
+    rails_benchmark_type = create(:benchmark_type, category: 'discourse_home', repo: rails, script_url: script_url)
 
     benchmark_result_type = create(:benchmark_result_type)
     ruby_benchmark_run = create(:release_benchmark_run,

--- a/test/models/benchmark_run_test.rb
+++ b/test/models/benchmark_run_test.rb
@@ -40,4 +40,36 @@ class BenchmarkRunTest < ActiveSupport::TestCase
       BenchmarkRun.latest_commit_benchmark_run(benchmark_type, benchmark_result_type)
     )
   end
+
+  test '.fetch_release_benchmark_runs' do
+    script_url = "https://raw.githubusercontent.com/org/repo/master/script/bench.rb"
+
+    ruby = create(:repo, name: 'ruby')
+    rails = create(:repo, name: 'rails')
+
+    ruby_release = create(:release, repo: ruby, version: '2.6.2')
+    rails_release = create(:release, repo: rails, version: '6.0.0')
+
+    ruby_benchmark_type = create(:benchmark_type, category: "discourse_home", repo: ruby, script_url: script_url)
+    rails_benchmark_type = create(:benchmark_type, category: "discourse_home", repo: rails, script_url: script_url)
+
+    benchmark_result_type = create(:benchmark_result_type)
+    ruby_benchmark_run = create(:release_benchmark_run,
+      benchmark_result_type: benchmark_result_type,
+      benchmark_type: ruby_benchmark_type,
+      initiator: ruby_release
+    )
+    rails_benchmark_run = create(:release_benchmark_run,
+      benchmark_result_type: benchmark_result_type,
+      benchmark_type: rails_benchmark_type,
+      initiator: rails_release
+    )
+    ruby_result = BenchmarkRun.fetch_release_benchmark_runs(ruby_benchmark_type, benchmark_result_type)
+    assert_equal(1, ruby_result.size)
+    assert_equal(ruby_benchmark_run.id, ruby_result.first.id)
+
+    rails_result = BenchmarkRun.fetch_release_benchmark_runs(rails_benchmark_type, benchmark_result_type)
+    assert_equal(1, rails_result.size)
+    assert_equal(rails_benchmark_run.id, rails_result.first.id)
+  end
 end


### PR DESCRIPTION
The problem here is that if you have 2 `benchmark_type` with the same `category` value (let's say "discourse_home") but different `repo_id`, you'd get results from both repos when viewing benchmark results for one of them only. I noticed this bug while I was making discourse benchmark run on rails releases which we already run on ruby commits.