### PR TITLE
 Feature: Allow users to run their own Ruby benchmarks

### DIFF
--- a/app/assets/javascripts/application/initialize.js
+++ b/app/assets/javascripts/application/initialize.js
@@ -56,6 +56,48 @@ var onSelectChange = function (event) {
   });
 }
 
+function onRangeTogglerChange() {
+  if (this.checked) {
+    $("#second-sha").parent().removeClass("hidden");
+  } else {
+    $("#second-sha").parent().addClass("hidden");
+  }
+}
+
+function onSubmitScript() {
+  var name = $('#script-name').val();
+  var url = $('#script-url').val();
+  var sha = $('#first-sha').val();
+  var sha2 = $('#second-sha').val();
+
+  var submitButton = $('#submit-script');
+  submitButton.attr("disabled", true);
+
+  var outlet = $('#response-outlet')
+  $.ajax("/user-scripts.json", {
+    type: "POST",
+    data: {
+      name: name,
+      url: url,
+      sha: sha,
+      sha2: sha2
+    },
+    success: function(message) {
+      outlet.removeClass('hidden');
+      outlet.addClass('white');
+      outlet.html(message);
+    },
+    error: function(error) {
+      outlet.removeClass('white');
+      outlet.removeClass('hidden');
+      outlet.html("An error occured, status: " + error.status + "<br>" + error.responseText);
+    },
+    complete: function() {
+      submitButton.attr("disabled", false);
+    }
+  });
+}
+
 $(document).on('turbolinks:load', function() {
   if (location.pathname) {
     $(".navbar-nav a[href='" + location.pathname + "']").addClass('current');
@@ -100,4 +142,6 @@ $(document).on('turbolinks:load', function() {
   });
 
   $('.result-types-form select').change(onSelectChange);
+  $('#range-toggler').on('change', onRangeTogglerChange);
+  $('#submit-script').on('click', onSubmitScript);
 });

--- a/app/assets/stylesheets/modules/_user-scripts.scss
+++ b/app/assets/stylesheets/modules/_user-scripts.scss
@@ -1,0 +1,17 @@
+.user-script-form {
+  width: 70%;
+  .commit-sha {
+    width: 50%;
+  }
+
+  #response-outlet {
+    color: white;
+    background: $brand-primary;
+    border-radius: 4px;
+    padding: 6px;
+    &.white {
+      color: $text-color;
+      background: $pre-bg;
+    }
+  }
+}

--- a/app/controllers/benchmark_runs_controller.rb
+++ b/app/controllers/benchmark_runs_controller.rb
@@ -13,7 +13,8 @@ class BenchmarkRunsController < APIController
 
     benchmark_type = repo.benchmark_types.find_or_create_by!(
       category: benchmark_type_params[:category],
-      script_url: benchmark_type_params[:script_url]
+      script_url: benchmark_type_params[:script_url],
+      from_user: [true, "true"].include?(benchmark_type_params[:from_user])
     )
 
     benchmark_type.update_attributes(digest: benchmark_type_params[:digest])
@@ -47,7 +48,7 @@ class BenchmarkRunsController < APIController
   end
 
   def benchmark_type_params
-    params.require(:benchmark_type).permit(:category, :script_url, :digest)
+    params.require(:benchmark_type).permit(:category, :script_url, :digest, :from_user)
   end
 
   def benchmark_result_type_params

--- a/app/controllers/benchmark_runs_controller.rb
+++ b/app/controllers/benchmark_runs_controller.rb
@@ -14,7 +14,7 @@ class BenchmarkRunsController < APIController
     benchmark_type = repo.benchmark_types.find_or_create_by!(
       category: benchmark_type_params[:category],
       script_url: benchmark_type_params[:script_url],
-      from_user: [true, "true"].include?(benchmark_type_params[:from_user])
+      from_user: [true, 'true'].include?(benchmark_type_params[:from_user])
     )
 
     benchmark_type.update_attributes(digest: benchmark_type_params[:digest])

--- a/app/controllers/repos_controller.rb
+++ b/app/controllers/repos_controller.rb
@@ -195,6 +195,17 @@ class ReposController < ApplicationController
 
   def set_repo_benchmarks
     @benchmarks = @repo.benchmark_types
+    set_rubybench_benchmarks
+    set_users_benchmarks
+    @benchmarks
+  end
+
+  def set_rubybench_benchmarks
+    @rubybench_benchmarks = @benchmarks.where(from_user: false)
+  end
+
+  def set_users_benchmarks
+    @users_benchmarks = @benchmarks.where(from_user: true)
   end
 
   def set_comparable_benchmarks

--- a/app/controllers/session_controller.rb
+++ b/app/controllers/session_controller.rb
@@ -1,6 +1,6 @@
 class SessionController < ApplicationController
   USERNAMES = %w{john osama sam tgx patrick}
-  TRUSTED_GROUP_NAME = "trusted-users"
+  TRUSTED_GROUP_NAME = 'trusted-users'
 
   def sso
     sso = DiscourseApi::SingleSignOn.parse(request.query_string, Rails.application.secrets.sso_secret)
@@ -41,7 +41,7 @@ class SessionController < ApplicationController
       trusted: false
     }.merge(permitted.to_h.symbolize_keys.slice(:username, :external_id, :trusted))
 
-    hash[:trusted] = [true, "true"].include?(hash[:trusted])
+    hash[:trusted] = [true, 'true'].include?(hash[:trusted])
     session[:user] = hash
     redirect_to '/'
   end

--- a/app/controllers/session_controller.rb
+++ b/app/controllers/session_controller.rb
@@ -1,12 +1,15 @@
 class SessionController < ApplicationController
+  USERNAMES = %w{john osama sam tgx patrick}
+  TRUSTED_GROUP_NAME = "trusted-users"
+
   def sso
     sso = DiscourseApi::SingleSignOn.parse(request.query_string, Rails.application.secrets.sso_secret)
     return_url = $redis.get(sso.nonce)
     if return_url.present?
       session[:user] = {
         username: sso.username,
-        email: sso.email,
-        external_id: sso.external_id
+        external_id: sso.external_id,
+        trusted: is_trusted?(sso)
       }
       redirect_to return_url
     else
@@ -20,7 +23,32 @@ class SessionController < ApplicationController
     sso.return_sso_url = "#{request.base_url}/sso"
     sso.nonce = SecureRandom.hex
     sso.sso_url = "#{AppSettings.forum_url}/session/sso_provider"
-    $redis.setex(sso.nonce, 10.minutes.to_i, '/')
+    path = session[:destination_url] || '/'
+    $redis.setex(sso.nonce, 10.minutes.to_i, path)
     redirect_to sso.to_url
+  end
+
+  def become
+    if Rails.env.production?
+      render plain: "Can't use this endpoint in production", status: 403
+      return
+    end
+
+    permitted = params.permit([:username, :external_id, :trusted])
+    hash = {
+      username: "#{USERNAMES.sample}#{SecureRandom.random_number(20)}",
+      external_id: SecureRandom.random_number(1000),
+      trusted: false
+    }.merge(permitted.to_h.symbolize_keys.slice(:username, :external_id, :trusted))
+
+    hash[:trusted] = [true, "true"].include?(hash[:trusted])
+    session[:user] = hash
+    redirect_to '/'
+  end
+
+  private
+
+  def is_trusted?(sso)
+    sso.admin || sso&.groups&.first&.split(',')&.include?(TRUSTED_GROUP_NAME)
   end
 end

--- a/app/controllers/user_scripts_controller.rb
+++ b/app/controllers/user_scripts_controller.rb
@@ -1,0 +1,36 @@
+class UserScriptsController < ApplicationController
+  before_action :ensure_trusted, except: :index
+
+  def index
+    if !current_user
+      session[:destination_url] = request.fullpath
+    elsif !current_user.trusted
+      render status: 403
+    end
+  end
+
+  def create
+    bench = UserBench.new(
+      params[:name],
+      params[:url],
+      params[:sha],
+      params[:sha2]
+    )
+    bench.validate!
+    if bench.valid?
+      bench.run
+
+      render plain: t('.index.successful_submit', path: "/ruby/ruby/commits?result_type=#{bench.name}")
+    else
+      render plain: bench.errors.join("\n"), status: 422
+    end
+  end
+
+  private
+
+  def ensure_trusted
+    if !current_user || !current_user.trusted
+      render plain: "Not allowed to post scripts", status: 403
+    end
+  end
+end

--- a/app/controllers/user_scripts_controller.rb
+++ b/app/controllers/user_scripts_controller.rb
@@ -30,7 +30,7 @@ class UserScriptsController < ApplicationController
 
   def ensure_trusted
     if !current_user || !current_user.trusted
-      render plain: "Not allowed to post scripts", status: 403
+      render plain: 'Not allowed to post scripts', status: 403
     end
   end
 end

--- a/app/jobs/remote_server_job.rb
+++ b/app/jobs/remote_server_job.rb
@@ -20,7 +20,7 @@ class RemoteServerJob < ActiveJob::Base
 
   RUBY_COMMIT_DISCOURSE = "#{SCRIPTS_PATH}/ruby/discourse/trunk.sh"
 
-  RUBY_CUSTOM_SCRIPTS = "#{SCRIPTS_PATH}/ruby/custom_scripts/receiver.sh"
+  RUBY_USER_SCRIPTS = "#{SCRIPTS_PATH}/ruby/user_scripts/receiver.sh"
 
   # Use keyword arguments once Rails 4.2.1 has been released.
   def perform(initiator_key, benchmark_group, options = {})
@@ -62,12 +62,12 @@ class RemoteServerJob < ActiveJob::Base
     )
   end
 
-  def ruby_custom_scripts(ssh, script_url, options)
-    commit_a = options[:commit_a]
-    commit_b = options[:commit_b]
+  def ruby_user_scripts(ssh, commit, options)
+    name = options[:name]
+    script_url = options[:script_url]
     ssh_exec!(
       ssh,
-      "#{RUBY_CUSTOM_SCRIPTS} #{script_url} #{commit_a} #{commit_b} #{secrets.api_name} #{secrets.api_password}"
+      "#{RUBY_USER_SCRIPTS} #{commit} #{name} #{script_url} #{secrets.api_name} #{secrets.api_password}"
     )
   end
 

--- a/app/jobs/run_user_bench.rb
+++ b/app/jobs/run_user_bench.rb
@@ -5,15 +5,15 @@ class RunUserBench < ActiveJob::Base
     commits = fetch_commits(start_date, stop_sha)
 
     repo = Repo.find_or_create_by!(
-      name: "ruby",
-      url: "https://github.com/tgxworld/ruby",
+      name: 'ruby',
+      url: 'https://github.com/tgxworld/ruby',
       organization: Organization.find_or_create_by!(
-        name: "ruby",
-        url: "https://github.com/tgxworld/",
+        name: 'ruby',
+        url: 'https://github.com/tgxworld/',
       )
     )
 
-    CommitsRunner.run(:api, commits, repo, '', smart: true, name: name, script_url: script_url, initiator_type: "user_scripts")
+    CommitsRunner.run(:api, commits, repo, '', smart: true, name: name, script_url: script_url, initiator_type: 'user_scripts')
   end
 
   private
@@ -22,7 +22,7 @@ class RunUserBench < ActiveJob::Base
     client = Octokit::Client.new(access_token: Rails.application.secrets.github_api_token, per_page: 100)
     commits = []
     done = false
-    batch = client.commits("ruby/ruby", { until: start_date })
+    batch = client.commits('ruby/ruby', until: start_date)
     response = client.last_response
     while batch.size > 0 && !done
       index = -1

--- a/app/jobs/run_user_bench.rb
+++ b/app/jobs/run_user_bench.rb
@@ -1,0 +1,46 @@
+class RunUserBench < ActiveJob::Base
+  queue_as :default
+
+  def perform(name, script_url, start_date, stop_sha)
+    commits = fetch_commits(start_date, stop_sha)
+
+    repo = Repo.find_or_create_by!(
+      name: "ruby",
+      url: "https://github.com/tgxworld/ruby",
+      organization: Organization.find_or_create_by!(
+        name: "ruby",
+        url: "https://github.com/tgxworld/",
+      )
+    )
+
+    CommitsRunner.run(:api, commits, repo, '', smart: true, name: name, script_url: script_url, initiator_type: "user_scripts")
+  end
+
+  private
+
+  def fetch_commits(start_date, stop_sha)
+    client = Octokit::Client.new(access_token: Rails.application.secrets.github_api_token, per_page: 100)
+    commits = []
+    done = false
+    batch = client.commits("ruby/ruby", { until: start_date })
+    response = client.last_response
+    while batch.size > 0 && !done
+      index = -1
+      batch.each_with_index do |c, ind|
+        if c.sha == stop_sha
+          done = true
+          index = ind
+        end
+      end
+      if done
+        commits.push(*batch[0..index])
+        break
+      else
+        commits.push(*batch)
+        response = response.rels[:next]&.get
+        batch = response&.data || []
+      end
+    end
+    commits
+  end
+end

--- a/app/services/user_bench.rb
+++ b/app/services/user_bench.rb
@@ -1,0 +1,87 @@
+class UserBench
+  attr_reader :errors, :name, :url, :sha, :sha2, :commits
+
+  def initialize(name, url, sha, sha2 = nil)
+    @name = name&.strip
+    @url = url&.strip
+    @sha = sha&.strip
+    @sha2 = sha2&.strip
+    @errors = []
+    @commits = []
+    @client = Octokit::Client.new(access_token: Rails.application.secrets.github_api_token)
+  end
+
+  def validate!
+    errors.push(err('missing_name')) if name.blank?
+    errors.push(err('missing_url')) if url.blank?
+    errors.push(err('missing_sha')) if sha.blank?
+    return if !valid?
+
+    errors.push(err('name_already_taken')) if name_taken?
+    errors.push(err('bad_url')) unless valid_url?
+    errors.push(err('unallowed_characters', name: name)) unless valid_name?
+
+    return if !valid?
+
+    validate_sha(sha)
+    validate_sha(sha2) if sha2.present?
+  end
+
+  def valid?
+    @errors.size == 0
+  end
+
+  def run
+    repo = Repo.find_or_create_by!(
+      name: "ruby",
+      url: "https://github.com/tgxworld/ruby",
+      organization: Organization.find_or_create_by!(
+        name: "ruby",
+        url: "https://github.com/tgxworld/",
+      )
+    )
+    BenchmarkType.create!(
+      category: name,
+      script_url: url,
+      from_user: true,
+      repo: repo
+    )
+
+    RunUserBench.perform_later(name, url, commits.last.commit.committer.date.iso8601, commits.first.sha)
+  end
+
+  private
+
+  def valid_url?
+    uri = URI.parse(url)
+    URI::HTTP === uri || URI::HTTPS === uri
+  rescue URI::InvalidURIError
+    false
+  end
+
+  def name_taken?
+    BenchmarkType.exists?(category: name)
+  end
+
+  def valid_name?
+    name.match?(/^[a-zA-Z0-9\-_]+$/)
+  end
+
+  def validate_sha(sha)
+    commit = @client.commit("ruby/ruby", sha)
+    add_commit(commit)
+  rescue Octokit::UnprocessableEntity
+    errors.push(err('bad_sha', sha: sha))
+  end
+
+  def add_commit(commit)
+    if commits.all? { |c| c.sha != commit.sha }
+      commits.push(commit)
+      commits.sort_by! { |c| c.commit.committer.date }
+    end
+  end
+
+  def err(key, *args)
+    I18n.t("user_scripts.errors.#{key}", *args)
+  end
+end

--- a/app/services/user_bench.rb
+++ b/app/services/user_bench.rb
@@ -33,11 +33,11 @@ class UserBench
 
   def run
     repo = Repo.find_or_create_by!(
-      name: "ruby",
-      url: "https://github.com/tgxworld/ruby",
+      name: 'ruby',
+      url: 'https://github.com/tgxworld/ruby',
       organization: Organization.find_or_create_by!(
-        name: "ruby",
-        url: "https://github.com/tgxworld/",
+        name: 'ruby',
+        url: 'https://github.com/tgxworld/',
       )
     )
     BenchmarkType.create!(
@@ -68,7 +68,7 @@ class UserBench
   end
 
   def validate_sha(sha)
-    commit = @client.commit("ruby/ruby", sha)
+    commit = @client.commit('ruby/ruby', sha)
     add_commit(commit)
   rescue Octokit::UnprocessableEntity
     errors.push(err('bad_sha', sha: sha))

--- a/app/views/repos/_form.html.haml
+++ b/app/views/repos/_form.html.haml
@@ -6,10 +6,13 @@
         %option{ value: "", selected: @benchmark.blank? || @form, disabled: true }
           = t('repos.select_benchmark')
 
-        - @benchmarks.each do |benchmark|
+        - @rubybench_benchmarks.each do |benchmark|
           %option{ value: benchmark.category, selected: @benchmark.present? && @benchmark.category == benchmark.category }
             = benchmark.category
 
+        - @users_benchmarks.each do |benchmark|
+          %option{ value: benchmark.category, selected: @benchmark.present? && @benchmark.category == benchmark.category }
+            = t('repos.user_scripts', name: benchmark.category)
     - if name == 'commits'
       .input-group
         .input-group-addon= t('repos.commits.show_last')

--- a/app/views/user_scripts/index.html.haml
+++ b/app/views/user_scripts/index.html.haml
@@ -1,0 +1,30 @@
+.container
+  %h2= t('.title')
+  %br
+  - if !current_user
+    %p= t('.login_required')
+    = link_to t('.login'), :login, class: 'btn btn-primary'
+  - elsif !current_user.trusted
+    %p= t('.not_enough_permissions')
+  - else
+    .user-script-form
+      .form-group
+        %label= t('.script_name')
+        %input.form-control#script-name
+      .form-group
+        %label= t('.script_url')
+        %input.form-control#script-url{ placeholder: t('.script_url_placeholder') }
+      .form-group
+        %label= t('.commit_sha')
+        %input.form-control.commit-sha#first-sha
+      .form-group.hidden
+        %label= t('.second_commit_sha')
+        %input.form-control.commit-sha#second-sha
+      .checkbox
+        %label
+          %input{ type: "checkbox", id: "range-toggler" }
+          = t('.range_commits')
+      .form-group
+        %button.btn.btn-primary#submit-script
+          = t('.submit')
+      %pre.hidden#response-outlet

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -10,6 +10,28 @@ en:
 
   submit: Submit
 
+  user_scripts:
+    index:
+      title: Benchmark your Ruby script
+      login_required: You need to login to see this page.
+      login: Login
+      not_enough_permissions: You don't have enough permissions to run a benchmark.
+      script_url: Script URL
+      script_name: Benchmark Name
+      range_commits: Range of commits
+      script_url_placeholder: e.g. https://raw.githubusercontent.com/ruby-bench/ruby-bench-suite/master/ruby/benchmark/app_factorial.rb
+      commit_sha: Commit SHA
+      second_commit_sha: Second commit SHA
+      submit: Submit
+      successful_submit: "Success! Results will be published <a href=\"%{path}\">here</a>."
+    errors:
+      missing_name: Missing Benchmark Name
+      missing_url: Missing Script URL
+      missing_sha: Missing Commit SHA
+      name_already_taken: Benchmarks Name is already taken
+      bad_url: Invalid Script URL
+      unallowed_characters: "\"%{name}\" contains unallowed characters. Allowed characters are: a-z, A-Z, 0-9, hyphens and underscores"
+      bad_sha: "Couldn't find Ruby commit for SHA %{sha}"
   organizations:
     index:
       title: Benchmarks
@@ -30,6 +52,7 @@ en:
       "%{category}" does not have any results. Please select another
       Benchmark Type.
     view_github: View on Github
+    user_scripts: "user_scripts/%{name}"
     run_locally_tip: |
       <p>You can run this benchmark locally using the <code>rubybench_runner</code> gem:</p>
       <pre>gem install rubybench_runner

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,7 @@
 Rails.application.routes.draw do
+  get 'user-scripts' => 'user_scripts#index'
+  post 'user-scripts.json' => 'user_scripts#create'
+
   if !Rails.env.test?
     require 'sidekiq/web'
 
@@ -24,6 +27,12 @@ Rails.application.routes.draw do
 
   get 'login' => 'session#login'
   get 'sso' => 'session#sso'
+
+  # this route is used to bypass SSO and login (used in tests).
+  # DON'T ENABLE IN PRODUCTION
+  if !Rails.env.production?
+    get 'become' => 'session#become'
+  end
 
   namespace :admin do
     resources :groups, except: [:show]

--- a/db/migrate/20190702200657_add_from_user_to_benchmark_types.rb
+++ b/db/migrate/20190702200657_add_from_user_to_benchmark_types.rb
@@ -1,0 +1,5 @@
+class AddFromUserToBenchmarkTypes < ActiveRecord::Migration[5.0]
+  def change
+    add_column :benchmark_types, :from_user, :boolean, null: false, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,12 +10,11 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170720115144) do
+ActiveRecord::Schema.define(version: 20190702200657) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
   enable_extension "hstore"
-  enable_extension "pg_trgm"
 
   create_table "benchmark_result_types", force: :cascade do |t|
     t.string   "name",       null: false
@@ -30,8 +29,8 @@ ActiveRecord::Schema.define(version: 20170720115144) do
     t.text     "environment",                             null: false
     t.datetime "created_at",                              null: false
     t.datetime "updated_at",                              null: false
-    t.integer  "initiator_id"
     t.string   "initiator_type"
+    t.integer  "initiator_id"
     t.integer  "benchmark_type_id",        default: 0,    null: false
     t.integer  "benchmark_result_type_id",                null: false
     t.boolean  "validity",                 default: true, null: false
@@ -40,12 +39,13 @@ ActiveRecord::Schema.define(version: 20170720115144) do
   end
 
   create_table "benchmark_types", force: :cascade do |t|
-    t.string   "category",   null: false
-    t.string   "script_url", null: false
-    t.integer  "repo_id",    null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.string   "category",                   null: false
+    t.string   "script_url",                 null: false
+    t.integer  "repo_id",                    null: false
+    t.datetime "created_at",                 null: false
+    t.datetime "updated_at",                 null: false
     t.string   "digest"
+    t.boolean  "from_user",  default: false, null: false
     t.index ["repo_id", "category", "script_url"], name: "index_benchmark_types_on_repo_id_and_category_and_script_url", unique: true, using: :btree
     t.index ["repo_id"], name: "index_benchmark_types_on_repo_id", using: :btree
   end

--- a/test/controllers/user_scripts_controller_test.rb
+++ b/test/controllers/user_scripts_controller_test.rb
@@ -3,43 +3,43 @@ require 'test_helper'
 class UserScriptsControllerTest < ActionDispatch::IntegrationTest
   include ActiveJob::TestHelper
 
-  test "anon users are prompted to login" do
+  test 'anon users are prompted to login' do
     get '/user-scripts'
     assert_response :success
-    assert_includes response.body, I18n.t("user_scripts.index.login_required")
+    assert_includes response.body, I18n.t('user_scripts.index.login_required')
   end
 
   test "untrusted logged-in users can't see form to submit scripts" do
     sign_in
     get '/user-scripts'
     assert_response :forbidden
-    assert_includes response.body, I18n.t("user_scripts.index.not_enough_permissions")
+    assert_includes response.body, I18n.t('user_scripts.index.not_enough_permissions')
   end
 
-  test "trusted users can see form" do
+  test 'trusted users can see form' do
     sign_in trusted: true
     get '/user-scripts'
     assert_response :success
-    assert_includes response.body, I18n.t("user_scripts.index.script_url")
-    assert_includes response.body, I18n.t("user_scripts.index.script_name")
+    assert_includes response.body, I18n.t('user_scripts.index.script_url')
+    assert_includes response.body, I18n.t('user_scripts.index.script_name')
   end
 
   test "untrusted users can't POST to #create" do
     sign_in
-    post '/user-scripts.json', params: { name: "some_benchmark", url: "http://script.com", sha: "asdsadsad" }
+    post '/user-scripts.json', params: { name: 'some_benchmark', url: 'http://script.com', sha: 'asdsadsad' }
     assert_response :forbidden
-    assert_equal BenchmarkType.where(category: "some_benchmark", from_user: true).count, 0
+    assert_equal BenchmarkType.where(category: 'some_benchmark', from_user: true).count, 0
   end
 
-  test "trusted users can POST to #create" do
+  test 'trusted users can POST to #create' do
     sign_in trusted: true
     assert_enqueued_with(job: RunUserBench) do
       VCR.use_cassette('github ruby 6ffef8d459') do
-        post '/user-scripts.json', params: { name: "some_benchmark", url: "http://script.com", sha: "6ffef8d459" }
+        post '/user-scripts.json', params: { name: 'some_benchmark', url: 'http://script.com', sha: '6ffef8d459' }
       end
     end
     assert_response :success
-    assert_equal response.body, "Success! Results will be published <a href=\"/ruby/ruby/commits?result_type=some_benchmark\">here</a>."
-    assert_equal BenchmarkType.where(category: "some_benchmark", from_user: true).count, 1
+    assert_equal response.body, 'Success! Results will be published <a href="/ruby/ruby/commits?result_type=some_benchmark">here</a>.'
+    assert_equal BenchmarkType.where(category: 'some_benchmark', from_user: true).count, 1
   end
 end

--- a/test/controllers/user_scripts_controller_test.rb
+++ b/test/controllers/user_scripts_controller_test.rb
@@ -1,0 +1,45 @@
+require 'test_helper'
+
+class UserScriptsControllerTest < ActionDispatch::IntegrationTest
+  include ActiveJob::TestHelper
+
+  test "anon users are prompted to login" do
+    get '/user-scripts'
+    assert_response :success
+    assert_includes response.body, I18n.t("user_scripts.index.login_required")
+  end
+
+  test "untrusted logged-in users can't see form to submit scripts" do
+    sign_in
+    get '/user-scripts'
+    assert_response :forbidden
+    assert_includes response.body, I18n.t("user_scripts.index.not_enough_permissions")
+  end
+
+  test "trusted users can see form" do
+    sign_in trusted: true
+    get '/user-scripts'
+    assert_response :success
+    assert_includes response.body, I18n.t("user_scripts.index.script_url")
+    assert_includes response.body, I18n.t("user_scripts.index.script_name")
+  end
+
+  test "untrusted users can't POST to #create" do
+    sign_in
+    post '/user-scripts.json', params: { name: "some_benchmark", url: "http://script.com", sha: "asdsadsad" }
+    assert_response :forbidden
+    assert_equal BenchmarkType.where(category: "some_benchmark", from_user: true).count, 0
+  end
+
+  test "trusted users can POST to #create" do
+    sign_in trusted: true
+    assert_enqueued_with(job: RunUserBench) do
+      VCR.use_cassette('github ruby 6ffef8d459') do
+        post '/user-scripts.json', params: { name: "some_benchmark", url: "http://script.com", sha: "6ffef8d459" }
+      end
+    end
+    assert_response :success
+    assert_equal response.body, "Success! Results will be published <a href=\"/ruby/ruby/commits?result_type=some_benchmark\">here</a>."
+    assert_equal BenchmarkType.where(category: "some_benchmark", from_user: true).count, 1
+  end
+end

--- a/test/jobs/remote_server_job_test.rb
+++ b/test/jobs/remote_server_job_test.rb
@@ -39,7 +39,7 @@ class RemoteServerJobTest < ActiveJob::TestCase
     )
 
     RemoteServerJob.new.perform(
-      @commit_hash, 'ruby_user_scripts', include_patterns: @patterns, name: "test_benchmark", script_url: "http://github.com"
+      @commit_hash, 'ruby_user_scripts', include_patterns: @patterns, name: 'test_benchmark', script_url: 'http://github.com'
     )
   end
 

--- a/test/jobs/remote_server_job_test.rb
+++ b/test/jobs/remote_server_job_test.rb
@@ -33,6 +33,16 @@ class RemoteServerJobTest < ActiveJob::TestCase
     )
   end
 
+  test '#perform ruby_user_scripts' do
+    @ssh.expects(:exec!).with(
+      "tsp #{RemoteServerJob::RUBY_USER_SCRIPTS} #{@commit_hash} test_benchmark http://github.com #{@api_name} #{@api_password}"
+    )
+
+    RemoteServerJob.new.perform(
+      @commit_hash, 'ruby_user_scripts', include_patterns: @patterns, name: "test_benchmark", script_url: "http://github.com"
+    )
+  end
+
   test '#perform ruby_release_discourse' do
     [
       'tsp docker pull rubybench/ruby_releases_discourse',

--- a/test/jobs/run_user_bench_test.rb
+++ b/test/jobs/run_user_bench_test.rb
@@ -1,0 +1,22 @@
+require 'test_helper'
+
+class RunUserBenchTest < ActiveJob::TestCase
+  include ActiveJob::TestHelper
+
+  test '#perform fetches commits and stores them in the db and runs benchmark for each commit' do
+    Commit.destroy_all
+    assert_enqueued_jobs(134, only: RemoteServerJob) do
+      VCR.use_cassette("github ruby 2019-07-02T06:02:16Z") do
+        RunUserBench.new.perform("user_benchmark", "http://github.com", "2019-07-02T06:02:16Z", "fe0ddf0e58e65ab3ae3d6e73382c3bebcd4541e5")
+      end
+    end
+
+    shas = Commit.pluck(:sha1)
+    assert_includes shas, "fe0ddf0e58e65ab3ae3d6e73382c3bebcd4541e5"
+    assert_includes shas, "6ffef8d459e6423bf4fe35cccb24345bad862448"
+
+    # 134 is the number of commits between the above 2 shas
+    # in the ruby repo excluding "ci skip" commits etc.
+    assert_equal shas.size, 134
+  end
+end

--- a/test/jobs/run_user_bench_test.rb
+++ b/test/jobs/run_user_bench_test.rb
@@ -6,14 +6,14 @@ class RunUserBenchTest < ActiveJob::TestCase
   test '#perform fetches commits and stores them in the db and runs benchmark for each commit' do
     Commit.destroy_all
     assert_enqueued_jobs(134, only: RemoteServerJob) do
-      VCR.use_cassette("github ruby 2019-07-02T06:02:16Z") do
-        RunUserBench.new.perform("user_benchmark", "http://github.com", "2019-07-02T06:02:16Z", "fe0ddf0e58e65ab3ae3d6e73382c3bebcd4541e5")
+      VCR.use_cassette('github ruby 2019-07-02T06:02:16Z') do
+        RunUserBench.new.perform('user_benchmark', 'http://github.com', '2019-07-02T06:02:16Z', 'fe0ddf0e58e65ab3ae3d6e73382c3bebcd4541e5')
       end
     end
 
     shas = Commit.pluck(:sha1)
-    assert_includes shas, "fe0ddf0e58e65ab3ae3d6e73382c3bebcd4541e5"
-    assert_includes shas, "6ffef8d459e6423bf4fe35cccb24345bad862448"
+    assert_includes shas, 'fe0ddf0e58e65ab3ae3d6e73382c3bebcd4541e5'
+    assert_includes shas, '6ffef8d459e6423bf4fe35cccb24345bad862448'
 
     # 134 is the number of commits between the above 2 shas
     # in the ruby repo excluding "ci skip" commits etc.

--- a/test/services/user_bench_test.rb
+++ b/test/services/user_bench_test.rb
@@ -1,0 +1,99 @@
+require 'test_helper'
+
+class UserBenchTest < ActiveSupport::TestCase
+  include ActiveJob::TestHelper
+
+  def err(key, *args)
+    I18n.t("user_scripts.errors.#{key}", *args)
+  end
+
+  def new_bench(name = nil, url = nil, sha = nil, sha2 = nil)
+    UserBench.new(name, url, sha, sha2)
+  end
+
+  def valid_name
+    "valid_name"
+  end
+
+  def valid_url
+    "http://github.com"
+  end
+
+  test '#validate! @name presence, uniqueness and allowed characters' do
+    bench = new_bench("")
+    bench.validate!
+    assert_includes bench.errors, err('missing_name')
+
+    BenchmarkType.create!(
+      category: "taken_name",
+      script_url: valid_url,
+      repo_id: 77
+    )
+
+    bench = new_bench("taken_name", valid_url, "asdasd")
+    bench.validate!
+    assert_includes bench.errors, err('name_already_taken')
+
+    bench = new_bench("/invalid name", valid_url, "dads")
+    bench.validate!
+    assert_includes bench.errors, err('unallowed_characters', name: "/invalid name")
+  end
+
+  test '#validate! @url presence and format' do
+    bench = new_bench(valid_name, "")
+    bench.validate!
+    assert_includes bench.errors, err('missing_url')
+
+    bench = new_bench(valid_name, "http:\\\\malformed;;", "dasd")
+    bench.validate!
+    assert_includes bench.errors, err('bad_url')
+  end
+
+  test '#validate! @sha presence and existence on github' do
+    bench = new_bench(valid_name, valid_url, "")
+    bench.validate!
+    assert_includes bench.errors, err('missing_sha')
+
+    bench = new_bench(valid_name, valid_url, "doesntexist")
+    VCR.use_cassette('github ruby doesntexist') do
+      bench.validate!
+    end
+    assert_includes bench.errors, err('bad_sha', sha: "doesntexist")
+  end
+
+  test '#validate! when everything is valid' do
+    bench = new_bench(valid_name, valid_url, "6ffef8d459")
+    VCR.use_cassette('github ruby 6ffef8d459') do
+      bench.validate!
+    end
+    assert bench.valid?
+    assert_equal bench.commits.size, 1
+    assert_equal bench.commits.first.sha, "6ffef8d459e6423bf4fe35cccb24345bad862448"
+  end
+
+  test "#validate! @sha2 existence on github only if it's given" do
+    bench = new_bench(valid_name, valid_url, "6ffef8d459", "doesntexist")
+    VCR.use_cassette('github ruby 6ffef8d459') do
+      VCR.use_cassette('github ruby doesntexist') do
+        bench.validate!
+      end
+    end
+    assert_includes bench.errors, err('bad_sha', sha: "doesntexist")
+  end
+
+  test "#validate! allows 2 shas" do
+    bench = new_bench(valid_name, valid_url, "6ffef8d459", "fe0ddf0e58")
+    VCR.use_cassette('github ruby 6ffef8d459') do
+      VCR.use_cassette('github ruby fe0ddf0e58') do
+        bench.validate!
+      end
+    end
+    assert bench.valid?
+    assert_equal bench.commits.size, 2
+    assert_equal bench.commits.map(&:sha), %w{fe0ddf0e58e65ab3ae3d6e73382c3bebcd4541e5 6ffef8d459e6423bf4fe35cccb24345bad862448}
+
+    first_commit_date = bench.commits.first.commit.committer.date
+    second_commit_date = bench.commits.second.commit.committer.date
+    assert first_commit_date < second_commit_date
+  end
+end

--- a/test/services/user_bench_test.rb
+++ b/test/services/user_bench_test.rb
@@ -12,77 +12,77 @@ class UserBenchTest < ActiveSupport::TestCase
   end
 
   def valid_name
-    "valid_name"
+    'valid_name'
   end
 
   def valid_url
-    "http://github.com"
+    'http://github.com'
   end
 
   test '#validate! @name presence, uniqueness and allowed characters' do
-    bench = new_bench("")
+    bench = new_bench('')
     bench.validate!
     assert_includes bench.errors, err('missing_name')
 
     BenchmarkType.create!(
-      category: "taken_name",
+      category: 'taken_name',
       script_url: valid_url,
       repo_id: 77
     )
 
-    bench = new_bench("taken_name", valid_url, "asdasd")
+    bench = new_bench('taken_name', valid_url, 'asdasd')
     bench.validate!
     assert_includes bench.errors, err('name_already_taken')
 
-    bench = new_bench("/invalid name", valid_url, "dads")
+    bench = new_bench('/invalid name', valid_url, 'dads')
     bench.validate!
-    assert_includes bench.errors, err('unallowed_characters', name: "/invalid name")
+    assert_includes bench.errors, err('unallowed_characters', name: '/invalid name')
   end
 
   test '#validate! @url presence and format' do
-    bench = new_bench(valid_name, "")
+    bench = new_bench(valid_name, '')
     bench.validate!
     assert_includes bench.errors, err('missing_url')
 
-    bench = new_bench(valid_name, "http:\\\\malformed;;", "dasd")
+    bench = new_bench(valid_name, 'http:\\\\malformed;;', 'dasd')
     bench.validate!
     assert_includes bench.errors, err('bad_url')
   end
 
   test '#validate! @sha presence and existence on github' do
-    bench = new_bench(valid_name, valid_url, "")
+    bench = new_bench(valid_name, valid_url, '')
     bench.validate!
     assert_includes bench.errors, err('missing_sha')
 
-    bench = new_bench(valid_name, valid_url, "doesntexist")
+    bench = new_bench(valid_name, valid_url, 'doesntexist')
     VCR.use_cassette('github ruby doesntexist') do
       bench.validate!
     end
-    assert_includes bench.errors, err('bad_sha', sha: "doesntexist")
+    assert_includes bench.errors, err('bad_sha', sha: 'doesntexist')
   end
 
   test '#validate! when everything is valid' do
-    bench = new_bench(valid_name, valid_url, "6ffef8d459")
+    bench = new_bench(valid_name, valid_url, '6ffef8d459')
     VCR.use_cassette('github ruby 6ffef8d459') do
       bench.validate!
     end
     assert bench.valid?
     assert_equal bench.commits.size, 1
-    assert_equal bench.commits.first.sha, "6ffef8d459e6423bf4fe35cccb24345bad862448"
+    assert_equal bench.commits.first.sha, '6ffef8d459e6423bf4fe35cccb24345bad862448'
   end
 
   test "#validate! @sha2 existence on github only if it's given" do
-    bench = new_bench(valid_name, valid_url, "6ffef8d459", "doesntexist")
+    bench = new_bench(valid_name, valid_url, '6ffef8d459', 'doesntexist')
     VCR.use_cassette('github ruby 6ffef8d459') do
       VCR.use_cassette('github ruby doesntexist') do
         bench.validate!
       end
     end
-    assert_includes bench.errors, err('bad_sha', sha: "doesntexist")
+    assert_includes bench.errors, err('bad_sha', sha: 'doesntexist')
   end
 
-  test "#validate! allows 2 shas" do
-    bench = new_bench(valid_name, valid_url, "6ffef8d459", "fe0ddf0e58")
+  test '#validate! allows 2 shas' do
+    bench = new_bench(valid_name, valid_url, '6ffef8d459', 'fe0ddf0e58')
     VCR.use_cassette('github ruby 6ffef8d459') do
       VCR.use_cassette('github ruby fe0ddf0e58') do
         bench.validate!

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -11,6 +11,10 @@ class ActiveSupport::TestCase
   # Add more helper methods to be used by all tests here...
 
   include FactoryGirl::Syntax::Methods
+
+  def sign_in(user = {})
+    get '/become', params: user
+  end
 end
 
 Sidekiq::Testing.fake!


### PR DESCRIPTION
This will allow certain users that are verified via [community.rubybench.org](https://community.rubybench.org) to run their own ruby benchmarks against one or a range of ruby commits. Results will gradually appear at https://rubybench.org/ruby/ruby/commits.

Screenshot:

![image](https://user-images.githubusercontent.com/17474474/60620952-2a0bd180-9de5-11e9-9a0c-250be440f395.png)